### PR TITLE
Use datafusion arrow re-export

### DIFF
--- a/ballista-cli/Cargo.lock
+++ b/ballista-cli/Cargo.lock
@@ -214,7 +214,6 @@ dependencies = [
 name = "ballista-cli"
 version = "0.7.0"
 dependencies = [
- "arrow",
  "ballista",
  "clap",
  "datafusion",

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -29,7 +29,6 @@ rust-version = "1.59"
 readme = "README.md"
 
 [dependencies]
-arrow = { version = "14.0.0" }
 ballista = { path = "../ballista/rust/client", version = "0.7.0" }
 clap = { version = "3", features = ["derive", "cargo"] }
 datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "9ea7dc6036a7b1d28c7450db4f26720b732a50de" }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

To make it easier to upgrade arrow in DataFusion

# What changes are included in this PR?

Removes the `arrow` version pin from ballista-cli, instead using the re-export from DataFusion

# Are there any user-facing changes?

No
