### PR TITLE
MINOR: Use `sqlparser` version exported by `datafusion` crates

### DIFF
--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -36,7 +36,6 @@ datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"
-sqlparser = "0.18"
 tempfile = "3"
 tokio = "1.0"
 

--- a/ballista/rust/client/src/context.rs
+++ b/ballista/rust/client/src/context.rs
@@ -19,7 +19,6 @@
 
 use log::info;
 use parking_lot::Mutex;
-use sqlparser::ast::Statement;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -41,7 +40,10 @@ use datafusion::logical_plan::{
 use datafusion::prelude::{
     AvroReadOptions, CsvReadOptions, ParquetReadOptions, SessionConfig, SessionContext,
 };
-use datafusion::sql::parser::{DFParser, Statement as DFStatement};
+use datafusion::sql::{
+    parser::{DFParser, Statement as DFStatement},
+    sqlparser::ast::Statement,
+};
 
 struct BallistaContextState {
     /// Ballista configuration

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -54,7 +54,6 @@ parse_arg = "0.1.3"
 prost = "0.10"
 prost-types = "0.10"
 serde = { version = "1", features = ["derive"] }
-sqlparser = "0.18"
 tokio = "1.0"
 tonic = "0.7"
 uuid = { version = "1.0", features = ["v4"] }

--- a/ballista/rust/core/src/error.rs
+++ b/ballista/rust/core/src/error.rs
@@ -25,7 +25,7 @@ use std::{
 
 use datafusion::arrow::error::ArrowError;
 use datafusion::error::DataFusionError;
-use sqlparser::parser;
+use datafusion::sql::sqlparser::parser;
 
 pub type Result<T> = result::Result<T, BallistaError>;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Ballista should always use the same version of sqlparser as DataFusion.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Remove Cargo dependency on `sqlparser`
- Use the version exported by DataFusion

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
