### PR TITLE
Add session token so we can register tables for FlightSQL

### DIFF
--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -31,8 +31,8 @@ readme = "README.md"
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
-datafusion-cli = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-cli = { path = "../../arrow-datafusion/datafusion-cli", features = [], optional = false }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -29,10 +29,10 @@ rust-version = "1.59"
 readme = "README.md"
 
 [dependencies]
-ballista = { path = "../ballista/rust/client", version = "0.7.0" }
+ballista = { path = "../ballista/rust/client", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
-datafusion-cli = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion-cli = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -31,8 +31,8 @@ readme = "README.md"
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-cli = { path = "../../arrow-datafusion/datafusion-cli", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion-cli = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -31,8 +31,8 @@ readme = "README.md"
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-cli = { path = "../../arrow-datafusion/datafusion-cli", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion-cli = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -31,8 +31,8 @@ readme = "README.md"
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
-datafusion-cli = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion-cli = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -31,8 +31,8 @@ readme = "README.md"
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
-datafusion-cli = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-cli = { path = "../../arrow-datafusion/datafusion-cli", features = [], optional = false }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -31,8 +31,8 @@ readme = "README.md"
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
-datafusion-cli = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion-cli = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -31,8 +31,8 @@ readme = "README.md"
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
-datafusion-cli = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
+datafusion-cli = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -36,7 +36,7 @@ datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"
-sqlparser = "0.18"
+sqlparser = "0.19"
 tempfile = "3"
 tokio = "1.0"
 

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.59"
 ballista-core = { path = "../core", features = [], optional = false }
 ballista-executor = { path = "../executor", features = [], optional = true }
 ballista-scheduler = { path = "../scheduler", features = [], optional = true }
-datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.59"
 ballista-core = { path = "../core", features = [], optional = false }
 ballista-executor = { path = "../executor", features = [], optional = true }
 ballista-scheduler = { path = "../scheduler", features = [], optional = true }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,12 +31,12 @@ rust-version = "1.59"
 ballista-core = { path = "../core", features = [], optional = false }
 ballista-executor = { path = "../executor", features = [], optional = true }
 ballista-scheduler = { path = "../scheduler", features = [], optional = true }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"
-sqlparser = "0.19"
+sqlparser = "0.20.0"
 tempfile = "3"
 tokio = "1.0"
 

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.59"
 ballista-core = { path = "../core", features = [], optional = false }
 ballista-executor = { path = "../executor", features = [], optional = true }
 ballista-scheduler = { path = "../scheduler", features = [], optional = true }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -28,11 +28,11 @@ edition = "2021"
 rust-version = "1.59"
 
 [dependencies]
-ballista-core = { path = "../core", version = "0.7.0" }
-ballista-executor = { path = "../executor", version = "0.7.0", optional = true }
-ballista-scheduler = { path = "../scheduler", version = "0.7.0", optional = true }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
+ballista-core = { path = "../core", features = [], optional = false }
+ballista-executor = { path = "../executor", features = [], optional = true }
+ballista-scheduler = { path = "../scheduler", features = [], optional = true }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.59"
 ballista-core = { path = "../core", features = [], optional = false }
 ballista-executor = { path = "../executor", features = [], optional = true }
 ballista-scheduler = { path = "../scheduler", features = [], optional = true }
-datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.59"
 ballista-core = { path = "../core", features = [], optional = false }
 ballista-executor = { path = "../executor", features = [], optional = true }
 ballista-scheduler = { path = "../scheduler", features = [], optional = true }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.59"
 ballista-core = { path = "../core", features = [], optional = false }
 ballista-executor = { path = "../executor", features = [], optional = true }
 ballista-scheduler = { path = "../scheduler", features = [], optional = true }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -54,7 +54,7 @@ parse_arg = "0.1.3"
 prost = "0.11.0"
 prost-types = "0.11.1"
 serde = { version = "1", features = ["derive"] }
-sqlparser = "0.18"
+sqlparser = "0.19"
 tokio = "1.0"
 tonic = "0.8"
 uuid = { version = "1.0", features = ["v4"] }

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -35,18 +35,18 @@ simd = ["datafusion/simd"]
 [dependencies]
 ahash = { version = "0.7", default-features = false }
 
-arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = [], optional = false }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
 futures = "0.3"
 hashbrown = "0.12"
 
 libloading = "0.7.3"
 log = "0.4"
-object_store = { path = "../../../../arrow-rs/object_store", features = [], optional = false }
+object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
 once_cell = "1.9.0"
 
 parking_lot = "0.12"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -39,14 +39,14 @@ arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
 futures = "0.3"
 hashbrown = "0.12"
 
 libloading = "0.7.3"
 log = "0.4"
-object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+object_store = "0.3.0"
 once_cell = "1.9.0"
 
 parking_lot = "0.12"
@@ -54,7 +54,7 @@ parse_arg = "0.1.3"
 prost = "0.11.0"
 prost-types = "0.11.1"
 serde = { version = "1", features = ["derive"] }
-sqlparser = "0.19"
+sqlparser = "0.20.0"
 tokio = "1.0"
 tonic = "0.8"
 uuid = { version = "1.0", features = ["v4"] }

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -39,8 +39,8 @@ arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
 futures = "0.3"
 hashbrown = "0.12"
 

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -35,18 +35,18 @@ simd = ["datafusion/simd"]
 [dependencies]
 ahash = { version = "0.7", default-features = false }
 
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
+arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = [], optional = false }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
 futures = "0.3"
 hashbrown = "0.12"
 
 libloading = "0.7.3"
 log = "0.4"
-object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
+object_store = { path = "../../../../arrow-rs/object_store", features = [], optional = false }
 once_cell = "1.9.0"
 
 parking_lot = "0.12"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -35,18 +35,18 @@ simd = ["datafusion/simd"]
 [dependencies]
 ahash = { version = "0.7", default-features = false }
 
-arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = [], optional = false }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
 futures = "0.3"
 hashbrown = "0.12"
 
 libloading = "0.7.3"
 log = "0.4"
-object_store = { path = "../../../../arrow-rs/object_store", features = [], optional = false }
+object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
 once_cell = "1.9.0"
 
 parking_lot = "0.12"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -35,12 +35,12 @@ simd = ["datafusion/simd"]
 [dependencies]
 ahash = { version = "0.7", default-features = false }
 
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+arrow-flight = "20.0.0"
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
 futures = "0.3"
 hashbrown = "0.12"
 

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -35,18 +35,18 @@ simd = ["datafusion/simd"]
 [dependencies]
 ahash = { version = "0.7", default-features = false }
 
-arrow-flight = { version = "18.0.0" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
 futures = "0.3"
 hashbrown = "0.12"
 
 libloading = "0.7.3"
 log = "0.4"
-object_store = "0.3.0"
+object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
 once_cell = "1.9.0"
 
 parking_lot = "0.12"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -35,28 +35,28 @@ simd = ["datafusion/simd"]
 [dependencies]
 ahash = { version = "0.7", default-features = false }
 
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
+arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = [], optional = false }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
 futures = "0.3"
 hashbrown = "0.12"
 
 libloading = "0.7.3"
 log = "0.4"
-object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
+object_store = { path = "../../../../arrow-rs/object_store", features = [], optional = false }
 once_cell = "1.9.0"
 
 parking_lot = "0.12"
 parse_arg = "0.1.3"
-prost = "0.10"
-prost-types = "0.10"
+prost = "0.11.0"
+prost-types = "0.11.1"
 serde = { version = "1", features = ["derive"] }
 sqlparser = "0.18"
 tokio = "1.0"
-tonic = "0.7"
+tonic = "0.8"
 uuid = { version = "1.0", features = ["v4"] }
 walkdir = "2.3.2"
 
@@ -65,4 +65,4 @@ tempfile = "3"
 
 [build-dependencies]
 rustc_version = "0.4.0"
-tonic-build = { version = "0.7" }
+tonic-build = { version = "0.8" }

--- a/ballista/rust/core/proto/datafusion.proto
+++ b/ballista/rust/core/proto/datafusion.proto
@@ -438,6 +438,8 @@ enum ScalarFunction {
   Coalesce=63;
   Power=64;
   StructFun=65;
+  FromUnixtime=66;
+  Atan2=67;
 }
 
 message ScalarFunctionNode {
@@ -593,53 +595,53 @@ message Field {
 }
 
 message FixedSizeBinary{
-  int32 length = 1;
+    int32 length = 1;
 }
 
 message Timestamp{
-  TimeUnit time_unit = 1;
-  string timezone = 2;
+    TimeUnit time_unit = 1;
+    string timezone = 2;
 }
 
 enum DateUnit{
-  Day = 0;
-  DateMillisecond = 1;
+    Day = 0;
+    DateMillisecond = 1;
 }
 
 enum TimeUnit{
-  Second = 0;
-  TimeMillisecond = 1;
-  Microsecond = 2;
-  Nanosecond = 3;
+    Second = 0;
+    TimeMillisecond = 1;
+    Microsecond = 2;
+    Nanosecond = 3;
 }
 
 enum IntervalUnit{
-  YearMonth = 0;
-  DayTime = 1;
-  MonthDayNano = 2;
+    YearMonth = 0;
+    DayTime = 1;
+    MonthDayNano = 2;
 }
 
 message Decimal{
-  uint64 whole = 1;
-  uint64 fractional = 2;
+    uint64 whole = 1;
+    uint64 fractional = 2;
 }
 
 message List{
-  Field field_type = 1;
+    Field field_type = 1;
 }
 
 message FixedSizeList{
-  Field field_type = 1;
-  int32 list_size = 2;
+    Field field_type = 1;
+    int32 list_size = 2;
 }
 
 message Dictionary{
-  ArrowType key = 1;
-  ArrowType value = 2;
+    ArrowType key = 1;
+    ArrowType value = 2;
 }
 
 message Struct{
-  repeated Field sub_field_types = 1;
+    repeated Field sub_field_types = 1;
 }
 
 enum UnionMode{
@@ -648,14 +650,14 @@ enum UnionMode{
 }
 
 message Union{
-  repeated Field union_types = 1;
-  UnionMode union_mode = 2;
-  repeated int32 type_ids = 3;
+    repeated Field union_types = 1;
+    UnionMode union_mode = 2;
+    repeated int32 type_ids = 3;
 }
 
 message ScalarListValue{
-  ScalarType datatype = 1;
-  repeated ScalarValue values = 2;
+    Field field = 1;
+    repeated ScalarValue values = 2;
 }
 
 message ScalarTimestampValue {
@@ -669,32 +671,32 @@ message ScalarTimestampValue {
 }
 
 message ScalarValue{
-  oneof value {
-    bool   bool_value = 1;
-    string utf8_value = 2;
-    string large_utf8_value = 3;
-    int32  int8_value = 4;
-    int32  int16_value = 5;
-    int32  int32_value = 6;
-    int64  int64_value = 7;
-    uint32 uint8_value = 8;
-    uint32 uint16_value = 9;
-    uint32 uint32_value = 10;
-    uint64 uint64_value = 11;
-    float  float32_value = 12;
-    double float64_value = 13;
-    //Literal Date32 value always has a unit of day
-    int32  date_32_value = 14;
-    ScalarListValue list_value = 17;
-    ScalarType null_list_value = 18;
+    oneof value {
+        bool   bool_value = 1;
+        string utf8_value = 2;
+        string large_utf8_value = 3;
+        int32  int8_value = 4;
+        int32  int16_value = 5;
+        int32  int32_value = 6;
+        int64  int64_value = 7;
+        uint32 uint8_value = 8;
+        uint32 uint16_value = 9;
+        uint32 uint32_value = 10;
+        uint64 uint64_value = 11;
+        float  float32_value = 12;
+        double float64_value = 13;
+        //Literal Date32 value always has a unit of day
+        int32  date_32_value = 14;
+        ScalarListValue list_value = 17;
+        ScalarType null_list_value = 18;
 
-    PrimitiveScalarType null_value = 19;
-    Decimal128 decimal128_value = 20;
-    int64 date_64_value = 21;
-    int32 interval_yearmonth_value = 24;
-    int64 interval_daytime_value = 25;
-    ScalarTimestampValue timestamp_value = 26;
-  }
+        PrimitiveScalarType null_value = 19;
+        Decimal128 decimal128_value = 20;
+        int64 date_64_value = 21;
+        int32 interval_yearmonth_value = 24;
+        int64 interval_daytime_value = 25;
+        ScalarTimestampValue timestamp_value = 26;
+    }
 }
 
 message Decimal128{
@@ -707,42 +709,42 @@ message Decimal128{
 // List
 enum PrimitiveScalarType{
 
-  BOOL = 0;     // arrow::Type::BOOL
-  UINT8 = 1;    // arrow::Type::UINT8
-  INT8 = 2;     // arrow::Type::INT8
-  UINT16 = 3;   // represents arrow::Type fields in src/arrow/type.h
-  INT16 = 4;
-  UINT32 = 5;
-  INT32 = 6;
-  UINT64 = 7;
-  INT64 = 8;
-  FLOAT32 = 9;
-  FLOAT64 = 10;
-  UTF8 = 11;
-  LARGE_UTF8 = 12;
-  DATE32 = 13;
-  TIME_MICROSECOND = 14;
-  TIME_NANOSECOND = 15;
-  NULL = 16;
+    BOOL = 0;     // arrow::Type::BOOL
+    UINT8 = 1;    // arrow::Type::UINT8
+    INT8 = 2;     // arrow::Type::INT8
+    UINT16 = 3;   // represents arrow::Type fields in src/arrow/type.h
+    INT16 = 4;
+    UINT32 = 5;
+    INT32 = 6;
+    UINT64 = 7;
+    INT64 = 8;
+    FLOAT32 = 9;
+    FLOAT64 = 10;
+    UTF8 = 11;
+    LARGE_UTF8 = 12;
+    DATE32 = 13;
+    TIME_MICROSECOND = 14;
+    TIME_NANOSECOND = 15;
+    NULL = 16;
 
-  DECIMAL128 = 17;
-  DATE64 = 20;
-  TIME_SECOND = 21;
-  TIME_MILLISECOND = 22;
-  INTERVAL_YEARMONTH = 23;
-  INTERVAL_DAYTIME = 24;
+    DECIMAL128 = 17;
+    DATE64 = 20;
+    TIME_SECOND = 21;
+    TIME_MILLISECOND = 22;
+    INTERVAL_YEARMONTH = 23;
+    INTERVAL_DAYTIME = 24;
 }
 
 message ScalarType{
-  oneof datatype{
-    PrimitiveScalarType scalar = 1;
-    ScalarListType list = 2;
-  }
+    oneof datatype{
+        PrimitiveScalarType scalar = 1;
+        ScalarListType list = 2;
+    }
 }
 
 message ScalarListType{
-  repeated string field_names = 3;
-  PrimitiveScalarType deepest_type = 2;
+    repeated string field_names = 3;
+    PrimitiveScalarType deepest_type = 2;
 }
 
 // Broke out into multiple message types so that type
@@ -750,40 +752,40 @@ message ScalarListType{
 //All types that are of the empty message types contain no additional metadata
 // about the type
 message ArrowType{
-  oneof arrow_type_enum{
-    EmptyMessage NONE = 1;     // arrow::Type::NA
-    EmptyMessage BOOL =  2;     // arrow::Type::BOOL
-    EmptyMessage UINT8 = 3;    // arrow::Type::UINT8
-    EmptyMessage INT8 =  4;     // arrow::Type::INT8
-    EmptyMessage UINT16 =5;   // represents arrow::Type fields in src/arrow/type.h
-    EmptyMessage INT16 = 6;
-    EmptyMessage UINT32 =7;
-    EmptyMessage INT32 = 8;
-    EmptyMessage UINT64 =9;
-    EmptyMessage INT64 =10 ;
-    EmptyMessage FLOAT16 =11 ;
-    EmptyMessage FLOAT32 =12 ;
-    EmptyMessage FLOAT64 =13 ;
-    EmptyMessage UTF8 =14 ;
-    EmptyMessage LARGE_UTF8 = 32;
-    EmptyMessage BINARY =15 ;
-    int32 FIXED_SIZE_BINARY =16 ;
-    EmptyMessage LARGE_BINARY = 31;
-    EmptyMessage DATE32 =17 ;
-    EmptyMessage DATE64 =18 ;
-    TimeUnit DURATION = 19;
-    Timestamp TIMESTAMP =20 ;
-    TimeUnit TIME32 =21 ;
-    TimeUnit TIME64 =22 ;
-    IntervalUnit INTERVAL =23 ;
-    Decimal DECIMAL =24 ;
-    List LIST =25;
-    List LARGE_LIST = 26;
-    FixedSizeList FIXED_SIZE_LIST = 27;
-    Struct STRUCT =28;
-    Union UNION =29;
-    Dictionary DICTIONARY =30;
-  }
+    oneof arrow_type_enum{
+        EmptyMessage NONE = 1;     // arrow::Type::NA
+        EmptyMessage BOOL =  2;     // arrow::Type::BOOL
+        EmptyMessage UINT8 = 3;    // arrow::Type::UINT8
+        EmptyMessage INT8 =  4;     // arrow::Type::INT8
+        EmptyMessage UINT16 =5;   // represents arrow::Type fields in src/arrow/type.h
+        EmptyMessage INT16 = 6;
+        EmptyMessage UINT32 =7;
+        EmptyMessage INT32 = 8;
+        EmptyMessage UINT64 =9;
+        EmptyMessage INT64 =10 ;
+        EmptyMessage FLOAT16 =11 ;
+        EmptyMessage FLOAT32 =12 ;
+        EmptyMessage FLOAT64 =13 ;
+        EmptyMessage UTF8 =14 ;
+        EmptyMessage LARGE_UTF8 = 32;
+        EmptyMessage BINARY =15 ;
+        int32 FIXED_SIZE_BINARY =16 ;
+        EmptyMessage LARGE_BINARY = 31;
+        EmptyMessage DATE32 =17 ;
+        EmptyMessage DATE64 =18 ;
+        TimeUnit DURATION = 19;
+        Timestamp TIMESTAMP =20 ;
+        TimeUnit TIME32 =21 ;
+        TimeUnit TIME64 =22 ;
+        IntervalUnit INTERVAL =23 ;
+        Decimal DECIMAL =24 ;
+        List LIST =25;
+        List LARGE_LIST = 26;
+        FixedSizeList FIXED_SIZE_LIST = 27;
+        Struct STRUCT =28;
+        Union UNION =29;
+        Dictionary DICTIONARY =30;
+    }
 }
 
 //Useful for representing an empty enum variant in rust

--- a/ballista/rust/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_writer.rs
@@ -354,11 +354,11 @@ impl ExecutionPlan for ShuffleWriterExec {
                 let mut num_bytes_builder = UInt64Builder::new(num_writers);
 
                 for loc in &part_loc {
-                    path_builder.append_value(loc.path.clone())?;
-                    partition_builder.append_value(loc.partition_id as u32)?;
-                    num_rows_builder.append_value(loc.num_rows)?;
-                    num_batches_builder.append_value(loc.num_batches)?;
-                    num_bytes_builder.append_value(loc.num_bytes)?;
+                    path_builder.append_value(loc.path.clone());
+                    partition_builder.append_value(loc.partition_id as u32);
+                    num_rows_builder.append_value(loc.num_rows);
+                    num_batches_builder.append_value(loc.num_batches);
+                    num_bytes_builder.append_value(loc.num_bytes);
                 }
 
                 // build arrays
@@ -374,7 +374,7 @@ impl ExecutionPlan for ShuffleWriterExec {
                     field_builders,
                 );
                 for _ in 0..num_writers {
-                    stats_builder.append(true)?;
+                    stats_builder.append(true);
                 }
                 let stats = Arc::new(stats_builder.finish());
 

--- a/ballista/rust/core/src/serde/mod.rs
+++ b/ballista/rust/core/src/serde/mod.rs
@@ -167,7 +167,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> BallistaCodec<T, 
 macro_rules! convert_required {
     ($PB:expr) => {{
         if let Some(field) = $PB.as_ref() {
-            Ok(field.try_into()?)
+            Ok(field.try_into().map_err(|e| proto_error("Failed to convert!"))?)
         } else {
             Err(proto_error("Missing required field in protobuf"))
         }

--- a/ballista/rust/core/src/serde/mod.rs
+++ b/ballista/rust/core/src/serde/mod.rs
@@ -167,7 +167,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> BallistaCodec<T, 
 macro_rules! convert_required {
     ($PB:expr) => {{
         if let Some(field) = $PB.as_ref() {
-            Ok(field.try_into().map_err(|e| proto_error("Failed to convert!"))?)
+            Ok(field.try_into().map_err(|_| proto_error("Failed to convert!"))?)
         } else {
             Err(proto_error("Missing required field in protobuf"))
         }

--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 
 use chrono::{TimeZone, Utc};
 use datafusion::arrow::datatypes::Schema;
+use datafusion::common::ScalarValue;
 use datafusion::datasource::listing::{FileRange, PartitionedFile};
 use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::execution::context::ExecutionProps;
@@ -68,10 +69,9 @@ pub(crate) fn parse_physical_expr(
             let pcol: Column = c.into();
             Arc::new(pcol)
         }
-        ExprType::Literal(scalar) => {
-            Arc::new(Literal::new(
-                convert_required!(scalar.value)?
-            ))
+        ExprType::Literal(literal) => {
+            let scalar_value: ScalarValue = literal.try_into()?;
+            Arc::new(Literal::new(scalar_value))
         }
         ExprType::BinaryExpr(binary_expr) => Arc::new(BinaryExpr::new(
             parse_required_physical_box_expr(

--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -69,7 +69,9 @@ pub(crate) fn parse_physical_expr(
             Arc::new(pcol)
         }
         ExprType::Literal(scalar) => {
-            Arc::new(Literal::new(convert_required!(scalar.value)?))
+            Arc::new(Literal::new(
+                convert_required!(scalar.value)?
+            ))
         }
         ExprType::BinaryExpr(binary_expr) => Arc::new(BinaryExpr::new(
             parse_required_physical_box_expr(

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -1463,7 +1463,7 @@ mod roundtrip_tests {
         };
 
         let predicate = datafusion::prelude::col("col").eq(datafusion::prelude::lit("1"));
-        roundtrip_test(Arc::new(ParquetExec::new(scan_config, Some(predicate))))
+        roundtrip_test(Arc::new(ParquetExec::new(scan_config, Some(predicate), None)))
     }
 
     #[test]

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -168,6 +168,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
                 Ok(Arc::new(ParquetExec::new(
                     decode_scan_config(scan.base_conf.as_ref().unwrap())?,
                     predicate,
+                    None,
                 )))
             }
             PhysicalPlanType::AvroScan(scan) => Ok(Arc::new(AvroExec::new(

--- a/ballista/rust/core/src/serde/scheduler/mod.rs
+++ b/ballista/rust/core/src/serde/scheduler/mod.rs
@@ -303,28 +303,28 @@ impl PartitionStats {
 
         let mut num_rows_builder = UInt64Builder::new(1);
         match self.num_rows {
-            Some(n) => num_rows_builder.append_value(n)?,
-            None => num_rows_builder.append_null()?,
+            Some(n) => num_rows_builder.append_value(n),
+            None => num_rows_builder.append_null(),
         }
         field_builders.push(Box::new(num_rows_builder) as Box<dyn ArrayBuilder>);
 
         let mut num_batches_builder = UInt64Builder::new(1);
         match self.num_batches {
-            Some(n) => num_batches_builder.append_value(n)?,
-            None => num_batches_builder.append_null()?,
+            Some(n) => num_batches_builder.append_value(n),
+            None => num_batches_builder.append_null(),
         }
         field_builders.push(Box::new(num_batches_builder) as Box<dyn ArrayBuilder>);
 
         let mut num_bytes_builder = UInt64Builder::new(1);
         match self.num_bytes {
-            Some(n) => num_bytes_builder.append_value(n)?,
-            None => num_bytes_builder.append_null()?,
+            Some(n) => num_bytes_builder.append_value(n),
+            None => num_bytes_builder.append_null(),
         }
         field_builders.push(Box::new(num_bytes_builder) as Box<dyn ArrayBuilder>);
 
         let mut struct_builder =
             StructBuilder::new(self.arrow_struct_fields(), field_builders);
-        struct_builder.append(true)?;
+        struct_builder.append(true);
         Ok(Arc::new(struct_builder.finish()))
     }
 

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -34,14 +34,14 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 anyhow = "1"
-arrow = { path = "../../../../arrow-rs/arrow", features = [], optional = false }
-arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = [], optional = false }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 hyper = "0.14.4"

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -40,8 +40,8 @@ async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 hyper = "0.14.4"

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -34,14 +34,14 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 anyhow = "1"
-arrow = { path = "../../../../arrow-rs/arrow", features = [], optional = false }
-arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = [], optional = false }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 hyper = "0.14.4"

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -34,14 +34,14 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 anyhow = "1"
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
+arrow = { path = "../../../../arrow-rs/arrow", features = [], optional = false }
+arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = [], optional = false }
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 hyper = "0.14.4"

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -40,8 +40,8 @@ async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 hyper = "0.14.4"

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -34,14 +34,14 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 anyhow = "1"
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
+arrow = { path = "../../../../arrow-rs/arrow", features = [], optional = false }
+arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = [], optional = false }
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 hyper = "0.14.4"
@@ -51,7 +51,7 @@ snmalloc-rs = { version = "0.3", optional = true }
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = "0.7"
+tonic = "0.8"
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -34,14 +34,14 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 anyhow = "1"
-arrow = { version = "18.0.0" }
-arrow-flight = { version = "18.0.0" }
+arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
 async-trait = "0.1.41"
-ballista-core = { path = "../core", version = "0.7.0" }
+ballista-core = { path = "../core", features = [], optional = false }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 hyper = "0.14.4"

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -34,14 +34,14 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 anyhow = "1"
-arrow = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+arrow = "20.0.0"
+arrow-flight = "20.0.0"
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 hyper = "0.14.4"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -40,6 +40,7 @@ arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee
 async-recursion = "1.0.0"
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
+base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
 datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -36,14 +36,14 @@ sled = ["sled_package", "tokio-stream"]
 
 [dependencies]
 anyhow = "1"
-arrow-flight = { version = "18.0.0", features = ["flight-sql-experimental"] }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = ["flight-sql-experimental"], optional = false }
 async-recursion = "1.0.0"
 async-trait = "0.1.41"
-ballista-core = { path = "../core", version = "0.7.0" }
+ballista-core = { path = "../core", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
 env_logger = "0.9"
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }
@@ -52,7 +52,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14.4"
 log = "0.4"
-object_store = "0.3.0"
+object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
 parking_lot = "0.12"
 parse_arg = "0.1.3"
 prost = "0.10"
@@ -67,7 +67,7 @@ uuid = { version = "1.0", features = ["v4"] }
 warp = "0.3"
 
 [dev-dependencies]
-ballista-core = { path = "../core", version = "0.7.0" }
+ballista-core = { path = "../core", features = [], optional = false }
 
 [build-dependencies]
 configure_me_codegen = "0.4.1"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -36,14 +36,14 @@ sled = ["sled_package", "tokio-stream"]
 
 [dependencies]
 anyhow = "1"
-arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = ["flight-sql-experimental"], optional = false }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = ["flight-sql-experimental"], optional = false }
 async-recursion = "1.0.0"
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
 env_logger = "0.9"
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }
@@ -52,7 +52,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14.4"
 log = "0.4"
-object_store = { path = "../../../../arrow-rs/object_store", features = [], optional = false }
+object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
 parking_lot = "0.12"
 parse_arg = "0.1.3"
 prost = "0.11.0"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -36,15 +36,15 @@ sled = ["sled_package", "tokio-stream"]
 
 [dependencies]
 anyhow = "1"
-arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = ["flight-sql-experimental"], optional = false }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["flight-sql-experimental"], optional = false }
 async-recursion = "1.0.0"
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
 env_logger = "0.9"
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }
@@ -53,7 +53,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14.4"
 log = "0.4"
-object_store = { path = "../../../../arrow-rs/object_store", features = [], optional = false }
+object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
 parking_lot = "0.12"
 parse_arg = "0.1.3"
 prost = "0.11.0"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -36,14 +36,14 @@ sled = ["sled_package", "tokio-stream"]
 
 [dependencies]
 anyhow = "1"
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = ["flight-sql-experimental"], optional = false }
+arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = ["flight-sql-experimental"], optional = false }
 async-recursion = "1.0.0"
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
 env_logger = "0.9"
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }
@@ -52,16 +52,16 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14.4"
 log = "0.4"
-object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
+object_store = { path = "../../../../arrow-rs/object_store", features = [], optional = false }
 parking_lot = "0.12"
 parse_arg = "0.1.3"
-prost = "0.10"
+prost = "0.11.0"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 sled_package = { package = "sled", version = "0.34", optional = true }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"], optional = true }
-tonic = "0.7"
+tonic = "0.8"
 tower = { version = "0.4" }
 uuid = { version = "1.0", features = ["v4"] }
 warp = "0.3"
@@ -71,4 +71,4 @@ ballista-core = { path = "../core", features = [], optional = false }
 
 [build-dependencies]
 configure_me_codegen = "0.4.1"
-tonic-build = { version = "0.7" }
+tonic-build = { version = "0.8" }

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -43,8 +43,8 @@ ballista-core = { path = "../core", features = [], optional = false }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
 env_logger = "0.9"
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }
@@ -53,7 +53,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14.4"
 log = "0.4"
-object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = [], optional = false }
+object_store = "0.3.0"
 parking_lot = "0.12"
 parse_arg = "0.1.3"
 prost = "0.11.0"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -36,15 +36,15 @@ sled = ["sled_package", "tokio-stream"]
 
 [dependencies]
 anyhow = "1"
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "30c94dbf1c422f81f8520b9956e96ab7b53c3f47", features = ["flight-sql-experimental"], optional = false }
+arrow-flight = { version = "20.0.0", features = ["flight-sql-experimental"], optional = false }
 async-recursion = "1.0.0"
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
 env_logger = "0.9"
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -36,15 +36,15 @@ sled = ["sled_package", "tokio-stream"]
 
 [dependencies]
 anyhow = "1"
-arrow-flight = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = ["flight-sql-experimental"], optional = false }
+arrow-flight = { path = "../../../../arrow-rs/arrow-flight", features = ["flight-sql-experimental"], optional = false }
 async-recursion = "1.0.0"
 async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion = { path = "../../../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-proto = { path = "../../../../arrow-datafusion/datafusion/proto", features = [], optional = false }
 env_logger = "0.9"
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }
@@ -53,7 +53,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14.4"
 log = "0.4"
-object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "6bb4b5ee16488c2a6427a5897bb6fbe334cc280e", features = [], optional = false }
+object_store = { path = "../../../../arrow-rs/object_store", features = [], optional = false }
 parking_lot = "0.12"
 parse_arg = "0.1.3"
 prost = "0.11.0"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -42,8 +42,8 @@ async-trait = "0.1.41"
 ballista-core = { path = "../core", features = [], optional = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
 env_logger = "0.9"
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }

--- a/ballista/rust/scheduler/src/flight_sql.rs
+++ b/ballista/rust/scheduler/src/flight_sql.rs
@@ -439,6 +439,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         query: CommandStatementQuery,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_statement ---");
         println!("Got query:\n{}", query.query);
 
         let ctx = self.get_ctx(&request)?;
@@ -454,6 +455,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         handle: CommandPreparedStatementQuery,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_prepared_statement ---");
         let ctx = self.get_ctx(&request)?;
         let handle = Uuid::from_slice(handle.prepared_statement_handle.as_slice())
             .map_err(|e| Status::internal(format!("Error decoding handle: {}", e)))?;
@@ -469,30 +471,34 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandGetCatalogs,
         _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_catalogs ---");
         Err(Status::unimplemented("Implement get_flight_info_catalogs"))
     }
 
     async fn get_flight_info_schemas(
         &self,
         _query: CommandGetDbSchemas,
-        request: Request<FlightDescriptor>,
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_schemas ---");
         Err(Status::unimplemented("Implement get_flight_info_schemas"))
     }
 
     async fn get_flight_info_tables(
         &self,
         _query: CommandGetTables,
-        request: Request<FlightDescriptor>,
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_tables ---");
         Err(Status::unimplemented("Implement get_flight_info_tables"))
     }
 
     async fn get_flight_info_table_types(
         &self,
         _query: CommandGetTableTypes,
-        request: Request<FlightDescriptor>,
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_table_types ---");
         Err(Status::unimplemented(
             "Implement get_flight_info_table_types",
         ))
@@ -501,8 +507,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn get_flight_info_sql_info(
         &self,
         _query: CommandGetSqlInfo,
-        request: Request<FlightDescriptor>,
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_sql_info ---");
         // TODO: implement for FlightSQL JDBC to work
         Err(Status::unimplemented("Implement CommandGetSqlInfo"))
     }
@@ -510,8 +517,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn get_flight_info_primary_keys(
         &self,
         _query: CommandGetPrimaryKeys,
-        request: Request<FlightDescriptor>,
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_primary_keys ---");
         Err(Status::unimplemented(
             "Implement get_flight_info_primary_keys",
         ))
@@ -520,8 +528,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn get_flight_info_exported_keys(
         &self,
         _query: CommandGetExportedKeys,
-        request: Request<FlightDescriptor>,
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_exported_keys ---");
         Err(Status::unimplemented(
             "Implement get_flight_info_exported_keys",
         ))
@@ -530,8 +539,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn get_flight_info_imported_keys(
         &self,
         _query: CommandGetImportedKeys,
-        request: Request<FlightDescriptor>,
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_imported_keys ---");
         Err(Status::unimplemented(
             "Implement get_flight_info_imported_keys",
         ))
@@ -540,8 +550,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn get_flight_info_cross_reference(
         &self,
         _query: CommandGetCrossReference,
-        request: Request<FlightDescriptor>,
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        println!("--- get_flight_info_cross_reference ---");
         Err(Status::unimplemented(
             "Implement get_flight_info_cross_reference",
         ))
@@ -552,6 +563,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _ticket: TicketStatementQuery,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_statement ---");
         // let handle = Uuid::from_slice(&ticket.statement_handle)
         //     .map_err(|e| Status::internal(format!("Error decoding ticket: {}", e)))?;
         // let statements = self.statements.try_lock()
@@ -565,6 +577,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandPreparedStatementQuery,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_prepared_statement ---");
         Err(Status::unimplemented("Implement do_get_prepared_statement"))
     }
 
@@ -573,6 +586,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandGetCatalogs,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_catalogs ---");
         Err(Status::unimplemented("Implement do_get_catalogs"))
     }
 
@@ -581,6 +595,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandGetDbSchemas,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_schemas ---");
         Err(Status::unimplemented("Implement do_get_schemas"))
     }
 
@@ -589,6 +604,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandGetTables,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_tables ---");
         Err(Status::unimplemented("Implement do_get_tables"))
     }
 
@@ -597,6 +613,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandGetTableTypes,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_table_types ---");
         Err(Status::unimplemented("Implement do_get_table_types"))
     }
 
@@ -605,6 +622,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandGetSqlInfo,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_sql_info ---");
         Err(Status::unimplemented("Implement do_get_sql_info"))
     }
     
@@ -613,6 +631,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandGetPrimaryKeys,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_primary_keys ---");
         Err(Status::unimplemented("Implement do_get_primary_keys"))
     }
 
@@ -621,13 +640,16 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandGetExportedKeys,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_exported_keys ---");
         Err(Status::unimplemented("Implement do_get_exported_keys"))
     }
+
     async fn do_get_imported_keys(
         &self,
         _query: CommandGetImportedKeys,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_imported_keys ---");
         Err(Status::unimplemented("Implement do_get_imported_keys"))
     }
     
@@ -636,6 +658,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandGetCrossReference,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        println!("--- do_get_cross_reference ---");
         Err(Status::unimplemented("Implement do_get_cross_reference"))
     }
 
@@ -645,6 +668,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _ticket: CommandStatementUpdate,
         _request: Request<Streaming<FlightData>>,
     ) -> Result<i64, Status> {
+        println!("--- do_put_statement_update ---");
         Err(Status::unimplemented("Implement do_put_statement_update"))
     }
 
@@ -653,6 +677,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: CommandPreparedStatementQuery,
         _request: Request<Streaming<FlightData>>,
     ) -> Result<Response<<Self as FlightService>::DoPutStream>, Status> {
+        println!("--- do_put_prepared_statement_query ---");
         Err(Status::unimplemented(
             "Implement do_put_prepared_statement_query",
         ))
@@ -663,7 +688,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         handle: CommandPreparedStatementUpdate,
         request: Request<Streaming<FlightData>>,
     ) -> Result<i64, Status> {
-        println!("do_put_prepared_statement_update");
+        println!("--- do_put_prepared_statement_update ---");
         let ctx = self.get_ctx(&request)?;
         let handle = Uuid::from_slice(handle.prepared_statement_handle.as_slice())
             .map_err(|e| Status::internal(format!("Error decoding handle: {}", e)))?;
@@ -678,6 +703,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         query: ActionCreatePreparedStatementRequest,
         request: Request<Action>,
     ) -> Result<ActionCreatePreparedStatementResult, Status> {
+        println!("--- do_action_create_prepared_statement ---");
         let ctx = self.get_ctx(&request)?;
         let plan = Self::prepare_statement(&query.query, &ctx).await?;
         let schema_bytes = self.df_schema_to_arrow(plan.schema())?;
@@ -696,6 +722,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         handle: ActionClosePreparedStatementRequest,
         _request: Request<Action>,
     ) {
+        println!("--- do_action_close_prepared_statement ---");
         let handle = Uuid::from_slice(handle.prepared_statement_handle.as_slice());
         let handle = if let Ok(handle) = handle {
             println!("Closing {}", handle);

--- a/ballista/rust/scheduler/src/flight_sql.rs
+++ b/ballista/rust/scheduler/src/flight_sql.rs
@@ -694,8 +694,8 @@ impl FlightSqlService for FlightSqlServiceImpl {
             .map_err(|e| Status::internal(format!("Error decoding handle: {}", e)))?;
         let plan = self.get_plan(&handle)?;
         let _ = self.execute_plan(ctx, &plan).await?;
-        println!("Sending 0 rows affected");
-        Ok(0)
+        println!("Sending -1 rows affected");
+        Ok(-1)
     }
 
     async fn do_action_create_prepared_statement(

--- a/ballista/rust/scheduler/src/flight_sql.rs
+++ b/ballista/rust/scheduler/src/flight_sql.rs
@@ -26,14 +26,13 @@ use arrow_flight::sql::{
     CommandPreparedStatementQuery, CommandPreparedStatementUpdate, CommandStatementQuery,
     CommandStatementUpdate, SqlInfo, TicketStatementQuery,
 };
-use arrow_flight::{
-    FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, Location, Ticket,
-};
+use arrow_flight::{FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest, HandshakeResponse, Location, Ticket};
 use log::{debug, error, warn};
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tonic::{Response, Status, Streaming};
+use tonic::{Request, Response, Status, Streaming};
 
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
 use crate::scheduler_server::SchedulerServer;
@@ -53,6 +52,7 @@ use datafusion::prelude::SessionContext;
 use datafusion_proto::protobuf::LogicalPlanNode;
 use prost::Message;
 use tokio::time::sleep;
+use tonic::codegen::futures_core::Stream;
 use uuid::Uuid;
 
 pub struct FlightSqlServiceImpl {
@@ -335,6 +335,18 @@ impl FlightSqlServiceImpl {
 #[tonic::async_trait]
 impl FlightSqlService for FlightSqlServiceImpl {
     type FlightService = FlightSqlServiceImpl;
+
+    async fn do_handshake(
+        &self,
+        _request: Request<Streaming<HandshakeRequest>>,
+    ) -> Result<
+        Response<Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>>,
+        Status,
+    > {
+        Err(Status::unimplemented(
+            "Handshake has no default implementation",
+        ))
+    }
 
     async fn get_flight_info_statement(
         &self,

--- a/ballista/rust/scheduler/src/flight_sql.rs
+++ b/ballista/rust/scheduler/src/flight_sql.rs
@@ -338,14 +338,47 @@ impl FlightSqlService for FlightSqlServiceImpl {
 
     async fn do_handshake(
         &self,
-        _request: Request<Streaming<HandshakeRequest>>,
+        request: Request<Streaming<HandshakeRequest>>,
     ) -> Result<
         Response<Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>>,
         Status,
     > {
-        Err(Status::unimplemented(
-            "Handshake has no default implementation",
-        ))
+        let basic = "Basic ";
+        let authorization = request
+            .metadata()
+            .get("authorization")
+            .ok_or(Status::invalid_argument("authorization field not present"))?
+            .to_str()
+            .map_err(|_| Status::invalid_argument("authorization not parsable"))?;
+        if !authorization.starts_with(basic) {
+            Err(Status::invalid_argument(format!(
+                "Auth type not implemented: {}",
+                authorization
+            )))?;
+        }
+        let base64 = &authorization[basic.len()..];
+        let bytes = base64::decode(base64)
+            .map_err(|_| Status::invalid_argument("authorization not parsable"))?;
+        let str = String::from_utf8(bytes)
+            .map_err(|_| Status::invalid_argument("authorization not parsable"))?;
+        let parts: Vec<_> = str.split(":").collect();
+        if parts.len() != 2 {
+            Err(Status::invalid_argument(format!(
+                "Invalid authorization header"
+            )))?;
+        }
+        let user = parts[0];
+        let pass = parts[1];
+        if user != "admin" || pass != "password" {
+            Err(Status::unauthenticated("Invalid credentials!"))?
+        }
+        let result = HandshakeResponse {
+            protocol_version: 0,
+            payload: Uuid::new_v4().as_bytes().to_vec(),
+        };
+        let result = Ok(result);
+        let output = futures::stream::iter(vec![result]);
+        return Ok(Response::new(Box::pin(output)));
     }
 
     async fn get_flight_info_statement(

--- a/ballista/rust/scheduler/src/main.rs
+++ b/ballista/rust/scheduler/src/main.rs
@@ -47,8 +47,6 @@ use ballista_core::config::TaskSchedulingPolicy;
 use ballista_core::serde::BallistaCodec;
 use log::info;
 use tonic::{Request, Status};
-use tonic::metadata::MetadataValue;
-use tonic::service::interceptor;
 
 #[macro_use]
 extern crate configure_me;

--- a/ballista/rust/scheduler/src/main.rs
+++ b/ballista/rust/scheduler/src/main.rs
@@ -112,7 +112,6 @@ async fn start_server(
             let keda_scaler = ExternalScalerServer::new(scheduler_server.clone());
 
             let mut tonic = TonicServer::builder()
-                // .layer(interceptor(check_auth))
                 .add_service(scheduler_grpc_server)
                 .add_service(flight_sql_server)
                 .add_service(keda_scaler)
@@ -134,9 +133,6 @@ async fn start_server(
                                 .map_ok(|res| res.map(EitherBody::Left))
                                 .map_err(Error::from),
                         );
-                    }
-                    if !req.headers().contains_key("auth-token-bin") {
-
                     }
                     Either::Right(
                         tonic

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-proto = { path = "../../arrow-datafusion/datafusion/proto", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-proto = { path = "../../arrow-datafusion/datafusion/proto", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion-proto = { path = "../../arrow-datafusion/datafusion/proto", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
-datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -32,9 +32,9 @@ simd = ["datafusion/simd"]
 snmalloc = ["snmalloc-rs"]
 
 [dependencies]
-ballista = { path = "../ballista/rust/client" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
+ballista = { path = "../ballista/rust/client", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }
@@ -47,4 +47,4 @@ structopt = { version = "0.3", default-features = false }
 tokio = { version = "^1.0", features = ["macros", "rt", "rt-multi-thread", "parking_lot"] }
 
 [dev-dependencies]
-ballista-core = { path = "../ballista/rust/core" }
+ballista-core = { path = "../ballista/rust/core", features = [], optional = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
-datafusion-proto = { path = "../../arrow-datafusion/datafusion/proto", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion-proto = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = [], optional = false }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -34,8 +34,8 @@ path = "examples/standalone-sql.rs"
 required-features = ["ballista/standalone"]
 
 [dependencies]
-ballista = { path = "../ballista/rust/client", version = "0.7.0" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
+ballista = { path = "../ballista/rust/client", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.10"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = [], optional = false }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = [], optional = false }
+datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,9 +35,9 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = [], optional = false }
+datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
 futures = "0.3"
 num_cpus = "1.13.0"
-prost = "0.10"
+prost = "0.11.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
-tonic = "0.7"
+tonic = "0.8"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { path = "../../arrow-datafusion/datafusion/core", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", features = [], optional = false }
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = [], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = [], optional = false }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11.0"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.57"
 name = "datafusion._internal"
 
 [dependencies]
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = ["pyarrow"], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = ["pyarrow"], optional = false }
 pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36"] }
 rand = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.57"
 name = "datafusion._internal"
 
 [dependencies]
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = ["pyarrow"], optional = false }
+datafusion = { path = "../../arrow-datafusion/datafusion/core", features = ["pyarrow"], optional = false }
 pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36"] }
 rand = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.57"
 name = "datafusion._internal"
 
 [dependencies]
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = ["pyarrow"], optional = false }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "master", features = ["pyarrow"], optional = false }
 pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36"] }
 rand = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.57"
 name = "datafusion._internal"
 
 [dependencies]
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = ["pyarrow"], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "be64e657790e2bd9fb1ae980198670d6baba4e84", features = ["pyarrow"], optional = false }
 pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36"] }
 rand = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.57"
 name = "datafusion._internal"
 
 [dependencies]
-datafusion = { path = "../../arrow-datafusion/datafusion/core", features = ["pyarrow"], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "1dd59c136bcaf8d5a82631a58af42da9d979ba92", features = ["pyarrow"], optional = false }
 pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36"] }
 rand = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.57"
 name = "datafusion._internal"
 
 [dependencies]
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "7607ace992a5a42840bf546221a8635e70e10885", features = ["pyarrow"] }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "6cca482d55ae150c889598d02ec55be2685dfb3b", features = ["pyarrow"], optional = false }
 pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36"] }
 rand = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.57"
 name = "datafusion._internal"
 
 [dependencies]
-datafusion = { path = "../../arrow-datafusion/datafusion/core", features = ["pyarrow"], optional = false }
+datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "2de9977df7425c234882a604c946fa367659ee2d", features = ["pyarrow"], optional = false }
 pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36"] }
 rand = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.57"
 name = "datafusion._internal"
 
 [dependencies]
-datafusion = { git = "https://github.com/spaceandtimelabs/arrow-datafusion.git", rev = "40cff64f4e066b9de6195c0fc6c64b9549412a88", features = ["pyarrow"], optional = false }
+datafusion = { path = "../../arrow-datafusion/datafusion/core", features = ["pyarrow"], optional = false }
 pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36"] }
 rand = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #112.

 # Rationale for this change

Since tables have to be registered to sessions, we need a session identifier or else each new FlightSql command runs on a clean slate with no tables. To fix this, we need a session identifier.

# What changes are included in this PR?

Implementation of a Basic Auth handshake, returning a UUID bearer token that the FlightSqlClient should send back with each request. Using this, I was successfully able to register the TPC-H customer table and select some data from it.

# Are there any user-facing changes?

They can start doing interesting things with JDBC / ODBC.
