### PR TITLE
Using tokio tracing for log file

### DIFF
--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -51,10 +51,10 @@ tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.7"
-uuid = { version = "1.0", features = ["v4"] }
 tracing = "0.1.36"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "ansi"] }
+uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -42,7 +42,6 @@ chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
 datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
 datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
-env_logger = "0.9"
 futures = "0.3"
 hyper = "0.14.4"
 log = "0.4"
@@ -53,6 +52,9 @@ tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "parki
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.7"
 uuid = { version = "1.0", features = ["v4"] }
+tracing = "0.1.36"
+tracing-appender = "0.2.2"
+tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "ansi"]}
 
 [dev-dependencies]
 

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -54,7 +54,7 @@ tonic = "0.7"
 uuid = { version = "1.0", features = ["v4"] }
 tracing = "0.1.36"
 tracing-appender = "0.2.2"
-tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "ansi"]}
+tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "ansi"] }
 
 [dev-dependencies]
 

--- a/ballista/rust/executor/executor_config_spec.toml
+++ b/ballista/rust/executor/executor_config_spec.toml
@@ -104,7 +104,20 @@ doc = "plugin dir"
 default = "std::string::String::from(\"\")"
 
 [[param]]
+name = "log_dir"
+type = "String"
+doc = "Log dir: a path to save log. This will create a new storage directory at the specified path if it does not already exist."
+default = "std::string::String::from(\"./logs\")"
+
+[[param]]
+name = "print_thread_info"
+type = "bool"
+doc = "Enable print thread ids and names in log file."
+default = "true"
+
+[[param]]
 name = "log_level_setting"
 type = "String"
 doc = "special log level for sub mod. link: https://docs.rs/env_logger/latest/env_logger/#enabling-logging. For example we want whole level is INFO but datafusion mode is DEBUG"
-default = "std::string::String::from(\"INFO, datafusion=INFO\")"
+default = "std::string::String::from(\"INFO,datafusion=INFO\")"
+

--- a/ballista/rust/executor/src/main.rs
+++ b/ballista/rust/executor/src/main.rs
@@ -74,15 +74,23 @@ async fn main() -> Result<()> {
     }
 
     let special_mod_log_level = opt.log_level_setting;
-    env_logger::builder()
-        .parse_filters(&*special_mod_log_level)
-        .format_timestamp_millis()
-        .init();
-
     let external_host = opt.external_host;
     let bind_host = opt.bind_host;
     let port = opt.bind_port;
     let grpc_port = opt.bind_grpc_port;
+    let log_dir = opt.log_dir;
+    let print_thread_info = opt.print_thread_info;
+
+    let scheduler_name = format!("executor_{}_{}", bind_host, port);
+    let log_file = tracing_appender::rolling::daily(log_dir, &scheduler_name);
+
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_thread_names(print_thread_info)
+        .with_thread_ids(print_thread_info)
+        .with_writer(log_file)
+        .with_env_filter(special_mod_log_level)
+        .init();
 
     let addr = format!("{}:{}", bind_host, port);
     let addr = addr

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -62,11 +62,11 @@ tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"], optional = true }
 tonic = "0.7"
 tower = { version = "0.4" }
-uuid = { version = "1.0", features = ["v4"] }
-warp = "0.3"
 tracing = "0.1.36"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "ansi"] }
+uuid = { version = "1.0", features = ["v4"] }
+warp = "0.3"
 
 [dev-dependencies]
 ballista-core = { path = "../core", version = "0.7.0" }

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -66,7 +66,7 @@ uuid = { version = "1.0", features = ["v4"] }
 warp = "0.3"
 tracing = "0.1.36"
 tracing-appender = "0.2.2"
-tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "ansi"]}
+tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "ansi"] }
 
 [dev-dependencies]
 ballista-core = { path = "../core", version = "0.7.0" }

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -44,7 +44,6 @@ clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
 datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
 datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "6a5de4fe08597896ab6375e3e4b76c5744dcfba7" }
-env_logger = "0.9"
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }
 futures = "0.3"
@@ -65,6 +64,9 @@ tonic = "0.7"
 tower = { version = "0.4" }
 uuid = { version = "1.0", features = ["v4"] }
 warp = "0.3"
+tracing = "0.1.36"
+tracing-appender = "0.2.2"
+tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "ansi"]}
 
 [dev-dependencies]
 ballista-core = { path = "../core", version = "0.7.0" }

--- a/ballista/rust/scheduler/scheduler_config_spec.toml
+++ b/ballista/rust/scheduler/scheduler_config_spec.toml
@@ -79,7 +79,19 @@ doc = "Sled dir: Opens a Db for saving schduler metadata at the specified path. 
 default = "std::string::String::from(\"\")"
 
 [[param]]
+name = "log_dir"
+type = "String"
+doc = "Log dir: a path to save log. This will create a new storage directory at the specified path if it does not already exist."
+default = "std::string::String::from(\"./logs\")"
+
+[[param]]
+name = "print_thread_info"
+type = "bool"
+doc = "Enable print thread ids and names in log file."
+default = "true"
+
+[[param]]
 name = "log_level_setting"
 type = "String"
 doc = "special log level for sub mod. link: https://docs.rs/env_logger/latest/env_logger/#enabling-logging. For example we want whole level is INFO but datafusion mode is DEBUG"
-default = "std::string::String::from(\"INFO, datafusion=INFO\")"
+default = "std::string::String::from(\"INFO,datafusion=INFO\")"

--- a/ballista/rust/scheduler/src/main.rs
+++ b/ballista/rust/scheduler/src/main.rs
@@ -157,14 +157,22 @@ async fn main() -> Result<()> {
     }
 
     let special_mod_log_level = opt.log_level_setting;
-    env_logger::builder()
-        .parse_filters(&*special_mod_log_level)
-        .format_timestamp_millis()
-        .init();
-
     let namespace = opt.namespace;
     let bind_host = opt.bind_host;
     let port = opt.bind_port;
+    let log_dir = opt.log_dir;
+    let print_thread_info = opt.print_thread_info;
+
+    let scheduler_name = format!("scheduler_{}_{}_{}", namespace, bind_host, port);
+    let log_file = tracing_appender::rolling::daily(log_dir, &scheduler_name);
+
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_thread_names(print_thread_info)
+        .with_thread_ids(print_thread_info)
+        .with_writer(log_file)
+        .with_env_filter(special_mod_log_level)
+        .init();
 
     let addr = format!("{}:{}", bind_host, port);
     let addr = addr.parse()?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #122 .

 # Rationale for this change
Enable thread info and cut log file by day.
Now logs look like:
```
arrow-ballista % cat logs/scheduler_ballista_0.0.0.0_50050.2022-08-10 
2022-08-10T07:28:45.457283Z  INFO main ThreadId(01) ballista_scheduler: Ballista v0.7.0 Scheduler listening on 0.0.0.0:50050    
2022-08-10T07:28:45.457489Z  INFO main ThreadId(01) ballista_scheduler: Starting Scheduler grpc server with task scheduling policy of PullStaged    
2022-08-10T07:28:45.458130Z  INFO main ThreadId(01) ballista_scheduler::scheduler_server::query_stage_scheduler: Starting QueryStageScheduler    
2022-08-10T07:28:45.458307Z  INFO tokio-runtime-worker ThreadId(17) ballista_core::event_loop: Starting the event loop query_stage    
2022-08-10T07:29:46.156777Z  INFO main ThreadId(01) ballista_scheduler: Ballista v0.7.0 Scheduler listening on 0.0.0.0:50050    
2022-08-10T07:29:46.157159Z  INFO main ThreadId(01) ballista_scheduler: Starting Scheduler grpc server with task scheduling policy of PullStaged    
2022-08-10T07:29:46.157729Z  INFO main ThreadId(01) ballista_scheduler::scheduler_server::query_stage_scheduler: Starting QueryStageScheduler    
2022-08-10T07:29:46.157922Z  INFO tokio-runtime-worker ThreadId(15) ballista_core::event_loop: Starting the event loop query_stage    
2022-08-10T07:30:09.766192Z  INFO main ThreadId(01) ballista_scheduler: Ballista v0.7.0 Scheduler listening on 0.0.0.0:50050    
2022-08-10T07:30:09.768707Z  INFO main ThreadId(01) ballista_scheduler: Starting Scheduler grpc server with task scheduling policy of PullStaged    
2022-08-10T07:30:09.769133Z  INFO main ThreadId(01) ballista_scheduler::scheduler_server::query_stage_scheduler: Starting QueryStageScheduler    
2022-08-10T07:30:09.769264Z  INFO tokio-runtime-worker ThreadId(09) ballista_core::event_loop: Starting the event loop query_stage    
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
