### PR TITLE
Use DataFusion 12.0.0-rc1 (and add support for DateTimeIntervalExpr and more binary operators)

### DIFF
--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -31,8 +31,8 @@ readme = "README.md"
 [dependencies]
 ballista = { path = "../ballista/rust/client", version = "0.7.0" }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
-datafusion-cli = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion-cli = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -31,8 +31,8 @@ readme = "README.md"
 [dependencies]
 ballista = { path = "../ballista/rust/client", version = "0.7.0" }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
-datafusion-cli = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion-cli = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -31,8 +31,8 @@ readme = "README.md"
 [dependencies]
 ballista = { path = "../ballista/rust/client", version = "0.7.0" }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
-datafusion-cli = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
+datafusion-cli = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.59"
 ballista-core = { path = "../core", version = "0.7.0" }
 ballista-executor = { path = "../executor", version = "0.7.0", optional = true }
 ballista-scheduler = { path = "../scheduler", version = "0.7.0", optional = true }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.59"
 ballista-core = { path = "../core", version = "0.7.0" }
 ballista-executor = { path = "../executor", version = "0.7.0", optional = true }
 ballista-scheduler = { path = "../scheduler", version = "0.7.0", optional = true }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.59"
 ballista-core = { path = "../core", version = "0.7.0" }
 ballista-executor = { path = "../executor", version = "0.7.0", optional = true }
 ballista-scheduler = { path = "../scheduler", version = "0.7.0", optional = true }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -39,8 +39,8 @@ arrow-flight = { version = "22.0.0" }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
 futures = "0.3"
 hashbrown = "0.12"
 

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -39,14 +39,14 @@ arrow-flight = { version = "22.0.0" }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
 futures = "0.3"
 hashbrown = "0.12"
 
 libloading = "0.7.3"
 log = "0.4"
-object_store = "0.4.0"
+object_store = "0.5.0"
 once_cell = "1.9.0"
 
 parking_lot = "0.12"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -39,8 +39,8 @@ arrow-flight = { version = "22.0.0" }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
 futures = "0.3"
 hashbrown = "0.12"
 

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -118,6 +118,8 @@ message PhysicalExprNode {
     PhysicalWindowExprNode window_expr = 15;
 
     PhysicalScalarUdfNode scalar_udf = 16;
+
+    PhysicalDateTimeIntervalExprNode date_time_interval_expr = 17;
   }
 }
 
@@ -159,6 +161,12 @@ message PhysicalAliasNode {
 }
 
 message PhysicalBinaryExprNode {
+  PhysicalExprNode l = 1;
+  PhysicalExprNode r = 2;
+  string op = 3;
+}
+
+message PhysicalDateTimeIntervalExprNode {
   PhysicalExprNode l = 1;
   PhysicalExprNode r = 2;
   string op = 3;

--- a/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -28,6 +28,7 @@ use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::window_function::WindowFunction;
 use datafusion::logical_plan::FunctionRegistry;
+use datafusion::physical_expr::expressions::DateTimeIntervalExpr;
 use datafusion::physical_expr::ScalarFunctionExpr;
 use datafusion::physical_plan::file_format::FileScanConfig;
 use datafusion::physical_plan::{
@@ -84,6 +85,12 @@ pub(crate) fn parse_physical_expr(
                 input_schema,
             )?,
         )),
+        ExprType::DateTimeIntervalExpr(expr) => Arc::new(DateTimeIntervalExpr::try_new(
+            parse_required_physical_box_expr(&expr.l, registry, "left", input_schema)?,
+            from_proto_binary_op(&expr.op)?,
+            parse_required_physical_box_expr(&expr.r, registry, "right", input_schema)?,
+            input_schema,
+        )?),
         ExprType::AggregateExpr(_) => {
             return Err(BallistaError::General(
                 "Cannot convert aggregate expr node to physical expression".to_owned(),

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -685,7 +685,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
             Ok(protobuf::PhysicalPlanNode {
                 physical_plan_type: Some(PhysicalPlanType::Explain(
                     protobuf::ExplainExecNode {
-                        schema: Some(exec.schema().as_ref().into()),
+                        schema: Some(exec.schema().as_ref().try_into()?),
                         stringified_plans: exec
                             .stringified_plans()
                             .iter()
@@ -797,7 +797,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
                             }
                         })
                         .collect();
-                    let schema = f.schema().into();
+                    let schema = f.schema().try_into()?;
                     Ok(protobuf::JoinFilter {
                         expression: Some(expression),
                         column_indices,
@@ -910,14 +910,14 @@ impl AsExecutionPlan for PhysicalPlanNode {
                         aggr_expr_name: agg_names,
                         mode: agg_mode as i32,
                         input: Some(Box::new(input)),
-                        input_schema: Some(input_schema.as_ref().into()),
+                        input_schema: Some(input_schema.as_ref().try_into()?),
                         null_expr,
                         groups,
                     },
                 ))),
             })
         } else if let Some(empty) = plan.downcast_ref::<EmptyExec>() {
-            let schema = empty.schema().as_ref().into();
+            let schema = empty.schema().as_ref().try_into()?;
             Ok(protobuf::PhysicalPlanNode {
                 physical_plan_type: Some(PhysicalPlanType::Empty(
                     protobuf::EmptyExecNode {
@@ -985,7 +985,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
                 physical_plan_type: Some(PhysicalPlanType::ShuffleReader(
                     protobuf::ShuffleReaderExecNode {
                         partition,
-                        schema: Some(exec.schema().as_ref().into()),
+                        schema: Some(exec.schema().as_ref().try_into()?),
                     },
                 )),
             })
@@ -1102,7 +1102,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
                 physical_plan_type: Some(PhysicalPlanType::Unresolved(
                     protobuf::UnresolvedShuffleExecNode {
                         stage_id: exec.stage_id as u32,
-                        schema: Some(exec.schema().as_ref().into()),
+                        schema: Some(exec.schema().as_ref().try_into()?),
                         input_partition_count: exec.input_partition_count as u32,
                         output_partition_count: exec.output_partition_count as u32,
                     },

--- a/ballista/rust/core/src/serde/physical_plan/to_proto.rs
+++ b/ballista/rust/core/src/serde/physical_plan/to_proto.rs
@@ -280,7 +280,7 @@ impl TryFrom<Arc<dyn PhysicalExpr>> for protobuf::PhysicalExprNode {
                 expr_type: Some(protobuf::physical_expr_node::ExprType::Cast(Box::new(
                     protobuf::PhysicalCastNode {
                         expr: Some(Box::new(cast.expr().clone().try_into()?)),
-                        arrow_type: Some(cast.cast_type().into()),
+                        arrow_type: Some(cast.cast_type().try_into()?),
                     },
                 ))),
             })
@@ -289,7 +289,7 @@ impl TryFrom<Arc<dyn PhysicalExpr>> for protobuf::PhysicalExprNode {
                 expr_type: Some(protobuf::physical_expr_node::ExprType::TryCast(
                     Box::new(protobuf::PhysicalTryCastNode {
                         expr: Some(Box::new(cast.expr().clone().try_into()?)),
-                        arrow_type: Some(cast.cast_type().into()),
+                        arrow_type: Some(cast.cast_type().try_into()?),
                     }),
                 )),
             })
@@ -310,7 +310,7 @@ impl TryFrom<Arc<dyn PhysicalExpr>> for protobuf::PhysicalExprNode {
                                 name: expr.name().to_string(),
                                 fun: fun.into(),
                                 args,
-                                return_type: Some(expr.return_type().into()),
+                                return_type: Some(expr.return_type().try_into()?),
                             },
                         ),
                     ),
@@ -321,7 +321,7 @@ impl TryFrom<Arc<dyn PhysicalExpr>> for protobuf::PhysicalExprNode {
                         protobuf::PhysicalScalarUdfNode {
                             name: expr.name().to_string(),
                             args,
-                            return_type: Some(expr.return_type().into()),
+                            return_type: Some(expr.return_type().try_into()?),
                         },
                     )),
                 })
@@ -450,7 +450,7 @@ impl TryFrom<&FileScanConfig> for protobuf::FileScanExecConf {
                 .iter()
                 .map(|n| *n as u32)
                 .collect(),
-            schema: Some(conf.file_schema.as_ref().into()),
+            schema: Some(conf.file_schema.as_ref().try_into()?),
             table_partition_cols: conf.table_partition_cols.to_vec(),
             object_store_url: conf.object_store_url.to_string(),
         })

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -40,8 +40,8 @@ async-trait = "0.1.41"
 ballista-core = { path = "../core", version = "0.7.0" }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
 futures = "0.3"
 hyper = "0.14.4"
 log = "0.4"

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -40,8 +40,8 @@ async-trait = "0.1.41"
 ballista-core = { path = "../core", version = "0.7.0" }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
 futures = "0.3"
 hyper = "0.14.4"
 log = "0.4"

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -40,8 +40,8 @@ async-trait = "0.1.41"
 ballista-core = { path = "../core", version = "0.7.0" }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
 futures = "0.3"
 hyper = "0.14.4"
 log = "0.4"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -45,8 +45,8 @@ ballista-core = { path = "../core", version = "0.7.0" }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }
 futures = "0.3"
@@ -55,7 +55,7 @@ http-body = "0.4"
 hyper = "0.14.4"
 itertools = "0.10.3"
 log = "0.4"
-object_store = "0.4.0"
+object_store = "0.5.0"
 parking_lot = "0.12"
 parse_arg = "0.1.3"
 prost = "0.11"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -45,8 +45,8 @@ ballista-core = { path = "../core", version = "0.7.0" }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }
 futures = "0.3"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -45,8 +45,8 @@ ballista-core = { path = "../core", version = "0.7.0" }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
 etcd-client = { version = "0.9", optional = true }
 flatbuffers = { version = "2.1.2" }
 futures = "0.3"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", version = "0.7.0" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", version = "0.7.0" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1" }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/rust/client", version = "0.7.0" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a" }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -36,7 +36,7 @@ default = ["mimalloc"]
 [dependencies]
 async-trait = "0.1"
 ballista = { path = "../ballista/rust/client" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a", features = ["pyarrow"] }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7", features = ["pyarrow"] }
 futures = "0.3"
 mimalloc = { version = "*", optional = true, default-features = false }
 pyo3 = { version = "~0.17.1", features = ["extension-module", "abi3", "abi3-py37"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -36,7 +36,7 @@ default = ["mimalloc"]
 [dependencies]
 async-trait = "0.1"
 ballista = { path = "../ballista/rust/client" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "97b3a4b37f54aaa52f8705db3e57b15ee98c24a7", features = ["pyarrow"] }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "12.0.0-rc1", features = ["pyarrow"] }
 futures = "0.3"
 mimalloc = { version = "*", optional = true, default-features = false }
 pyo3 = { version = "~0.17.1", features = ["extension-module", "abi3", "abi3-py37"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -36,7 +36,7 @@ default = ["mimalloc"]
 [dependencies]
 async-trait = "0.1"
 ballista = { path = "../ballista/rust/client" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae", features = ["pyarrow"] }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "deea8c3e8436614c7333025d7c44917487ef439a", features = ["pyarrow"] }
 futures = "0.3"
 mimalloc = { version = "*", optional = true, default-features = false }
 pyo3 = { version = "~0.17.1", features = ["extension-module", "abi3", "abi3-py37"] }

--- a/python/src/functions.rs
+++ b/python/src/functions.rs
@@ -169,6 +169,7 @@ macro_rules! aggregate_function {
                 fun: AggregateFunction::$FUNC,
                 args: args.into_iter().map(|e| e.into()).collect(),
                 distinct,
+                filter: None,
             };
             expr.into()
         }

--- a/python/src/udaf.rs
+++ b/python/src/udaf.rs
@@ -97,7 +97,7 @@ impl Accumulator for RustAccumulator {
 }
 
 pub fn to_rust_accumulator(accum: PyObject) -> AccumulatorFunctionImplementation {
-    Arc::new(move || -> Result<Box<dyn Accumulator>> {
+    Arc::new(move |_| -> Result<Box<dyn Accumulator>> {
         let accum = Python::with_gil(|py| {
             accum
                 .call0(py)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-ballista/issues/201 (via https://github.com/apache/arrow-datafusion/pull/3441)

Also adds support for DateIntervalExpr

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

- Support queries with DATE + INTERVAL expressions
- Support more binary operations

This allows me to run more queries against Ballista

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Serde addition
- Use `try_into` instead of `into` due to changes in DataFusion

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
