### PR TITLE
[Python] Allow some config options to be set when creating context

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -43,7 +43,7 @@ import pyarrow
 f = ballista.functions
 
 # create a context
-ctx = ballista.SessionContext()
+ctx = ballista.BallistaContext("localhost", 50050)
 
 # create a RecordBatch and a new DataFrame from it
 batch = pyarrow.RecordBatch.from_arrays(
@@ -63,6 +63,14 @@ result = df.collect()[0]
 
 assert result.column(0) == pyarrow.array([5, 7, 9])
 assert result.column(1) == pyarrow.array([-3, -3, -3])
+```
+
+### Specifying Configuration Options
+
+Configuration settings can be specified when creating the context.
+
+```python
+ctx = ballista.BallistaContext("localhost", 50050, shuffle_partitions = 200, batch_size = 16384)
 ```
 
 ### UDFs

--- a/python/src/ballista_context.rs
+++ b/python/src/ballista_context.rs
@@ -38,10 +38,20 @@ pub(crate) struct PyBallistaContext {
 #[pymethods]
 impl PyBallistaContext {
     #[new]
-    #[args(port = "50050")]
-    fn new(py: Python, host: &str, port: u16) -> PyResult<Self> {
+    #[args(port = "50050", shuffle_partitions = 4, batch_size = 8192)]
+    fn new(
+        py: Python,
+        host: &str,
+        port: u16,
+        shuffle_partitions: usize,
+        batch_size: usize,
+    ) -> PyResult<Self> {
         let config = BallistaConfig::builder()
-            .set("ballista.shuffle.partitions", "4")
+            .set(
+                "ballista.shuffle.partitions",
+                &format!("{}", shuffle_partitions),
+            )
+            .set("ballista.batch.size", &format!("{}", batch_size))
             .set("ballista.with_information_schema", "true")
             .build()
             .map_err(BallistaError::from)?;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-ballista/issues/203

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Allow jobs to be tuned from Python

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Allow some basic configs to be set from Python

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
