### PR TITLE
Make executor logging less verbose

### DIFF
--- a/ballista/rust/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_reader.rs
@@ -136,29 +136,7 @@ impl ExecutionPlan for ShuffleReaderExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default => {
-                let loc_str = self
-                    .partition
-                    .iter()
-                    .enumerate()
-                    .map(|(partition_id, locations)| {
-                        format!(
-                            "[partition={} paths={}]",
-                            partition_id,
-                            locations
-                                .iter()
-                                .map(|l| l.path.clone())
-                                .collect::<Vec<String>>()
-                                .join(",")
-                        )
-                    })
-                    .collect::<Vec<String>>()
-                    .join(", ");
-                write!(
-                    f,
-                    "ShuffleReaderExec: partition_locations({})={}",
-                    self.partition.len(),
-                    loc_str
-                )
+                write!(f, "ShuffleReaderExec: partitions={}", self.partition.len(),)
             }
         }
     }

--- a/ballista/rust/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/rust/core/src/execution_plans/shuffle_reader.rs
@@ -36,7 +36,7 @@ use futures::{StreamExt, TryStreamExt};
 use datafusion::arrow::error::ArrowError;
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use log::{debug, info};
+use log::debug;
 
 /// ShuffleReaderExec reads partitions that have already been materialized by a ShuffleWriterExec
 /// being executed by an executor
@@ -136,7 +136,7 @@ impl ExecutionPlan for ShuffleReaderExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default => {
-                write!(f, "ShuffleReaderExec: partitions={}", self.partition.len(),)
+                write!(f, "ShuffleReaderExec: partitions={}", self.partition.len())
             }
         }
     }

--- a/ballista/rust/scheduler/src/planner.rs
+++ b/ballista/rust/scheduler/src/planner.rs
@@ -34,7 +34,7 @@ use datafusion::physical_plan::{
     with_new_children_if_necessary, ExecutionPlan, Partitioning,
 };
 
-use log::info;
+use log::{debug, info};
 
 type PartialQueryStageResult = (Arc<dyn ExecutionPlan>, Vec<Arc<ShuffleWriterExec>>);
 

--- a/python/README.md
+++ b/python/README.md
@@ -43,7 +43,7 @@ import pyarrow
 f = ballista.functions
 
 # create a context
-ctx = ballista.SessionContext()
+ctx = ballista.BallistaContext("localhost", 50050)
 
 # create a RecordBatch and a new DataFrame from it
 batch = pyarrow.RecordBatch.from_arrays(
@@ -63,6 +63,14 @@ result = df.collect()[0]
 
 assert result.column(0) == pyarrow.array([5, 7, 9])
 assert result.column(1) == pyarrow.array([-3, -3, -3])
+```
+
+### Specifying Configuration Options
+
+Configuration settings can be specified when creating the context.
+
+```python
+ctx = ballista.BallistaContext("localhost", 50050, shuffle_partitions = 200, batch_size = 16384)
 ```
 
 ### UDFs

--- a/python/src/ballista_context.rs
+++ b/python/src/ballista_context.rs
@@ -38,10 +38,20 @@ pub(crate) struct PyBallistaContext {
 #[pymethods]
 impl PyBallistaContext {
     #[new]
-    #[args(port = "50050")]
-    fn new(py: Python, host: &str, port: u16) -> PyResult<Self> {
+    #[args(port = "50050", shuffle_partitions = 4, batch_size = 8192)]
+    fn new(
+        py: Python,
+        host: &str,
+        port: u16,
+        shuffle_partitions: usize,
+        batch_size: usize,
+    ) -> PyResult<Self> {
         let config = BallistaConfig::builder()
-            .set("ballista.shuffle.partitions", "4")
+            .set(
+                "ballista.shuffle.partitions",
+                &format!("{}", shuffle_partitions),
+            )
+            .set("ballista.batch.size", &format!("{}", batch_size))
             .set("ballista.with_information_schema", "true")
             .build()
             .map_err(BallistaError::from)?;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I am starting to do some performance profiling and tuning and I cannot read the plans because they are so huge.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Change some logging from `info!` to `debug!`
- Makes the output much less verbose for shuffle reader exec:

```
2022-09-15T02:03:17.337693Z  INFO tokio-runtime-worker ThreadId(49) ballista_scheduler::display: === [Xl4tDeB/15] Stage finished, physical plan with metrics ===
ShuffleWriterExec: None, metrics=[output_rows=100, input_rows=100, repart_time=1ns, write_time=534.050341ms]
  GlobalLimitExec: skip=0, fetch=100, metrics=[output_rows=100, elapsed_compute=1.839828ms, spill_count=0, spilled_bytes=0, mem_used=0]
    SortExec: [c_customer_id@0 ASC NULLS LAST], metrics=[output_rows=8192, elapsed_compute=518.201936ms, spill_count=0, spilled_bytes=0]
      CoalescePartitionsExec, metrics=[output_rows=772575, elapsed_compute=51.948µs, spill_count=0, spilled_bytes=0, mem_used=0]
        ShuffleReaderExec: partitions=24, metrics=[fetch_time=392.660551ms]
```

Note that `ShuffleWriterExec` was already concise. This makes `ShuffleReaderExec` more consistent with that.

Do we still have a need to output all the paths to all the location being read? It was helpful early on in development for sure.

Ideally I would make this configurable but there does not seem to be an easy way to hook this into the config system?


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, easier to read logs, less disk space used.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
