### PR TITLE
Add scheduler UI to ballista-scheduler Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,7 @@
 .git
-ballista-cli
 ci
 conbench
 dev
-examples
 python
 **/docs
 **/target

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
 .git
 ci
 conbench
-dev
+dev/dist
+dev/release
 python
 **/docs
 **/target

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
 .git
-ballista/ui/*
+ballista-cli
 ci
 conbench
 dev
+examples
+python
 **/docs
 **/target
 **/CHANGELOG.md

--- a/ballista/ui/scheduler/src/components/Header.tsx
+++ b/ballista/ui/scheduler/src/components/Header.tsx
@@ -67,7 +67,7 @@ export const Header: React.FunctionComponent<HeaderProps> = ({
             <a
               rel={"noreferrer"}
               target={"_blank"}
-              href={"https://ballistacompute.org/docs/"}
+              href={"https://arrow.apache.org/ballista/"}
             >
               <Button
                 mr={4}
@@ -80,7 +80,7 @@ export const Header: React.FunctionComponent<HeaderProps> = ({
             </a>
             <a
               rel="noreferrer"
-              href={"https://github.com/apache/arrow-datafusion"}
+              href={"https://github.com/apache/arrow-ballista"}
               target={"_blank"}
             >
               <Button colorScheme="blue" size="sm" rightIcon={<AiFillGithub />}>

--- a/benchmarks/docker-compose.yaml
+++ b/benchmarks/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
     ports:
       - 2379:2379
   ballista-scheduler:
-    image: ballista:0.8.0
+    image: ballista-scheduler:0.8.0
     command: "/scheduler --config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0 --bind-port 50050"
     environment:
       - RUST_LOG=info
@@ -31,7 +31,7 @@ services:
     depends_on:
       - etcd
   ballista-executor:
-    image: ballista:0.8.0
+    image: ballista-executor:0.8.0
     command: "/executor --bind-host 0.0.0.0 --bind-port 50051 --scheduler-host ballista-scheduler"
     scale: 2
     environment:

--- a/benchmarks/docker-compose.yaml
+++ b/benchmarks/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - 2379:2379
   ballista-scheduler:
     image: apache/arrow-ballista-scheduler:0.8.0
-    command: "/scheduler --config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0 --bind-port 50050"
+    command: "--config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0 --bind-port 50050"
     environment:
       - RUST_LOG=info
     volumes:
@@ -32,7 +32,7 @@ services:
       - etcd
   ballista-executor:
     image: apache/arrow-ballista-executor:0.8.0
-    command: "/executor --bind-host 0.0.0.0 --bind-port 50051 --scheduler-host ballista-scheduler"
+    command: "--bind-host 0.0.0.0 --bind-port 50051 --scheduler-host ballista-scheduler"
     scale: 2
     environment:
       - RUST_LOG=ballista=debug,info

--- a/benchmarks/docker-compose.yaml
+++ b/benchmarks/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
     ports:
       - 2379:2379
   ballista-scheduler:
-    image: ballista-scheduler:0.8.0
+    image: apache/arrow-ballista-scheduler:0.8.0
     command: "/scheduler --config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0 --bind-port 50050"
     environment:
       - RUST_LOG=info
@@ -31,7 +31,7 @@ services:
     depends_on:
       - etcd
   ballista-executor:
-    image: ballista-executor:0.8.0
+    image: apache/arrow-ballista-executor:0.8.0
     command: "/executor --bind-host 0.0.0.0 --bind-port 50051 --scheduler-host ballista-scheduler"
     scale: 2
     environment:
@@ -41,7 +41,7 @@ services:
     depends_on:
       - ballista-scheduler
   ballista-client:
-    image: ballista:0.8.0
+    image: apache/arrow-ballista-benchmarks:0.8.0
     command: "/bin/sh" # do nothing
     environment:
       - RUST_LOG=info

--- a/dev/build-ballista-docker.sh
+++ b/dev/build-ballista-docker.sh
@@ -20,8 +20,8 @@
 set -e
 
 . ./dev/build-set-env.sh
-#docker build -t apache/arrow-ballista-base:$BALLISTA_VERSION -f dev/docker/ballista-base.dockerfile .
-#docker build -t apache/arrow-ballista:$BALLISTA_VERSION -f dev/docker/ballista.dockerfile .
-#docker build -t apache/arrow-ballista-executor:$BALLISTA_VERSION -f dev/docker/ballista-executor.dockerfile .
-docker build -t apache/arrow-ballista-scheduler:$BALLISTA_VERSION -f dev/docker/ballista-scheduler.dockerfile .
-#docker build -t apache/arrow-ballista-benchmarks:$BALLISTA_VERSION -f dev/docker/ballista-benchmarks.dockerfile .
+docker build -t apache/arrow-ballista-base:$BALLISTA_VERSION -f dev/docker/ballista-base.dockerfile .
+docker build --build-arg VERSION=$BALLISTA_VERSION -t apache/arrow-ballista:$BALLISTA_VERSION -f dev/docker/ballista.dockerfile .
+docker build --build-arg VERSION=$BALLISTA_VERSION -t apache/arrow-ballista-executor:$BALLISTA_VERSION -f dev/docker/ballista-executor.dockerfile .
+docker build --build-arg VERSION=$BALLISTA_VERSION -t apache/arrow-ballista-scheduler:$BALLISTA_VERSION -f dev/docker/ballista-scheduler.dockerfile .
+docker build --build-arg VERSION=$BALLISTA_VERSION -t apache/arrow-ballista-benchmarks:$BALLISTA_VERSION -f dev/docker/ballista-benchmarks.dockerfile .

--- a/dev/build-ballista-docker.sh
+++ b/dev/build-ballista-docker.sh
@@ -20,5 +20,8 @@
 set -e
 
 . ./dev/build-set-env.sh
-docker build -t ballista-base:$BALLISTA_VERSION -f dev/docker/ballista-base.dockerfile .
-docker build -t ballista:$BALLISTA_VERSION -f dev/docker/ballista.dockerfile .
+#docker build -t apache/arrow-ballista-base:$BALLISTA_VERSION -f dev/docker/ballista-base.dockerfile .
+#docker build -t apache/arrow-ballista:$BALLISTA_VERSION -f dev/docker/ballista.dockerfile .
+#docker build -t apache/arrow-ballista-executor:$BALLISTA_VERSION -f dev/docker/ballista-executor.dockerfile .
+docker build -t apache/arrow-ballista-scheduler:$BALLISTA_VERSION -f dev/docker/ballista-scheduler.dockerfile .
+#docker build -t apache/arrow-ballista-benchmarks:$BALLISTA_VERSION -f dev/docker/ballista-benchmarks.dockerfile .

--- a/dev/docker/ballista-benchmarks.dockerfile
+++ b/dev/docker/ballista-benchmarks.dockerfile
@@ -1,5 +1,22 @@
-ARG VERSION=0.8.0
-FROM ballista:$VERSION
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG VERSION
+FROM apache/arrow-ballista:$VERSION
 
 ADD benchmarks/run.sh /
 RUN mkdir /queries

--- a/dev/docker/ballista-benchmarks.dockerfile
+++ b/dev/docker/ballista-benchmarks.dockerfile
@@ -1,0 +1,11 @@
+ARG VERSION=0.8.0
+FROM ballista:$VERSION
+
+ADD benchmarks/run.sh /
+RUN mkdir /queries
+COPY benchmarks/queries/ /queries/
+
+ENV RUST_LOG=info
+ENV RUST_BACKTRACE=full
+
+CMD ["/run.sh"]

--- a/dev/docker/ballista-executor.dockerfile
+++ b/dev/docker/ballista-executor.dockerfile
@@ -24,5 +24,5 @@ ENV RUST_BACKTRACE=full
 # Expose Ballista Executor gRPC port
 EXPOSE 50051
 
-ADD dev/docker/scheduler-entrypoint.sh /
-ENTRYPOINT ["/scheduler-entrypoint.sh"]
+ADD dev/docker/executor-entrypoint.sh /
+ENTRYPOINT ["/executor-entrypoint.sh"]

--- a/dev/docker/ballista-executor.dockerfile
+++ b/dev/docker/ballista-executor.dockerfile
@@ -1,5 +1,22 @@
-ARG VERSION=0.8.0
-FROM ballista:$VERSION
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG VERSION
+FROM apache/arrow-ballista:$VERSION
 
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full

--- a/dev/docker/ballista-executor.dockerfile
+++ b/dev/docker/ballista-executor.dockerfile
@@ -1,0 +1,7 @@
+ARG VERSION=0.8.0
+FROM ballista:$VERSION
+
+ENV RUST_LOG=info
+ENV RUST_BACKTRACE=full
+
+CMD ["/executor"]

--- a/dev/docker/ballista-executor.dockerfile
+++ b/dev/docker/ballista-executor.dockerfile
@@ -21,4 +21,8 @@ FROM apache/arrow-ballista:$VERSION
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
 
-CMD ["/executor"]
+# Expose Ballista Executor gRPC port
+EXPOSE 50051
+
+ADD dev/docker/scheduler-entrypoint.sh /
+ENTRYPOINT ["/scheduler-entrypoint.sh"]

--- a/dev/docker/ballista-scheduler.dockerfile
+++ b/dev/docker/ballista-scheduler.dockerfile
@@ -26,8 +26,9 @@ RUN yarn
 RUN yarn build
 
 FROM apache/arrow-ballista:$VERSION
-COPY --from=ui-build /app/build /usr/share/nginx/html
 RUN apt -y install nginx
+RUN rm -rf /var/www/html/*
+COPY --from=ui-build /app/build /var/www/html
 
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full

--- a/dev/docker/ballista-scheduler.dockerfile
+++ b/dev/docker/ballista-scheduler.dockerfile
@@ -1,0 +1,18 @@
+ARG VERSION=0.8.0
+FROM ballista:$VERSION
+
+# Scheduler UI
+RUN apt -y install nodejs npm nginx
+RUN npm install --global yarn
+RUN npm install --save node-releases
+RUN mkdir /tmp/ballista-ui
+WORKDIR /tmp/ballista-ui
+
+COPY ballista/ui/scheduler ./
+RUN yarn
+RUN yarn build
+
+ENV RUST_LOG=info
+ENV RUST_BACKTRACE=full
+
+CMD ["/scheduler"]

--- a/dev/docker/ballista-scheduler.dockerfile
+++ b/dev/docker/ballista-scheduler.dockerfile
@@ -1,5 +1,22 @@
-ARG VERSION=0.8.0
-FROM ballista:$VERSION
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG VERSION
+FROM apache/arrow-ballista:$VERSION
 
 # Scheduler UI
 RUN apt -y install nodejs npm nginx
@@ -10,7 +27,12 @@ WORKDIR /tmp/ballista-ui
 
 COPY ballista/ui/scheduler ./
 RUN yarn
-RUN yarn build
+
+# TODO this fails with:
+# Error: Cannot find module '../../data/browsers'
+#RUN yarn build
+
+# TODO start nginx in background to serve the UI
 
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full

--- a/dev/docker/ballista-scheduler.dockerfile
+++ b/dev/docker/ballista-scheduler.dockerfile
@@ -39,4 +39,4 @@ EXPOSE 80
 EXPOSE 50050
 
 ADD dev/docker/scheduler-entrypoint.sh /
-CMD ["/scheduler-entrypoint.sh"]
+ENTRYPOINT ["/scheduler-entrypoint.sh"]

--- a/dev/docker/ballista.dockerfile
+++ b/dev/docker/ballista.dockerfile
@@ -22,9 +22,9 @@
 # as a mounted directory.
 
 ARG RELEASE_FLAG=--release
-ARG VERSION=0.8.0
+ARG VERSION
 
-FROM ballista-base:$VERSION AS base
+FROM apache/arrow-ballista-base:$VERSION AS base
 WORKDIR /tmp/ballista
 RUN apt-get -y install cmake
 RUN cargo install cargo-chef --version 0.1.34
@@ -86,7 +86,7 @@ ENV RELEASE_FLAG=${RELEASE_FLAG}
 RUN if [ -z "$RELEASE_FLAG" ]; then mv /tmp/ballista/target/debug/tpch /tpch; else mv /tmp/ballista/target/release/tpch /tpch; fi
 
 # Copy the binary into a new container for a smaller docker image
-FROM ballista-base:$VERSION
+FROM apache/arrow-ballista-base:$VERSION
 
 COPY --from=builder /executor /
 

--- a/dev/docker/ballista.dockerfile
+++ b/dev/docker/ballista.dockerfile
@@ -22,7 +22,7 @@
 # as a mounted directory.
 
 ARG RELEASE_FLAG=--release
-ARG VERSION=0.7.0
+ARG VERSION=0.8.0
 
 FROM ballista-base:$VERSION AS base
 WORKDIR /tmp/ballista
@@ -93,10 +93,6 @@ COPY --from=builder /executor /
 COPY --from=builder /scheduler /
 
 COPY --from=builder /tpch /
-
-ADD benchmarks/run.sh /
-RUN mkdir /queries
-COPY benchmarks/queries/ /queries/
 
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full

--- a/dev/docker/executor-entrypoint.sh
+++ b/dev/docker/executor-entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/executor "$@"

--- a/dev/docker/executor-entrypoint.sh
+++ b/dev/docker/executor-entrypoint.sh
@@ -1,2 +1,20 @@
 #!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 /executor "$@"

--- a/dev/docker/scheduler-entrypoint.sh
+++ b/dev/docker/scheduler-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "Starting nginx to serve Ballista Scheduler web UI on port 80"
+nohup nginx -g "daemon off;" &
+echo "Starting Ballista Scheduler"
+/scheduler

--- a/dev/docker/scheduler-entrypoint.sh
+++ b/dev/docker/scheduler-entrypoint.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 echo "Starting nginx to serve Ballista Scheduler web UI on port 80"
 nohup nginx -g "daemon off;" &
 /scheduler "$@"

--- a/dev/docker/scheduler-entrypoint.sh
+++ b/dev/docker/scheduler-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 echo "Starting nginx to serve Ballista Scheduler web UI on port 80"
 nohup nginx -g "daemon off;" &
-echo "Starting Ballista Scheduler"
-/scheduler
+/scheduler "$@"

--- a/docs/source/user-guide/deployment/docker-compose.md
+++ b/docs/source/user-guide/deployment/docker-compose.md
@@ -33,7 +33,10 @@ cd arrow-datafusion
 ./dev/build-ballista-docker.sh
 ```
 
-This will create an image with the tag `ballista:0.7.0`.
+This will create the following images:
+
+- `apache/arrow-ballista-scheduler:0.8.0`
+- `apache/arrow-ballista-executor:0.8.0`
 
 ## Start a cluster
 
@@ -48,10 +51,11 @@ services:
     image: quay.io/coreos/etcd:v3.4.9
     command: "etcd -advertise-client-urls http://etcd:2379 -listen-client-urls http://0.0.0.0:2379"
   ballista-scheduler:
-    image: ballista:0.8.0
-    command: "/scheduler --config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0 --bind-port 50050"
+    image: apache/arrow-ballista-scheduler:0.8.0
+    command: "--config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0 --bind-port 50050"
     ports:
       - "50050:50050"
+      - "80:8080"
     environment:
       - RUST_LOG=info
     volumes:
@@ -59,8 +63,8 @@ services:
     depends_on:
       - etcd
   ballista-executor:
-    image: ballista:0.8.0
-    command: "/executor --bind-host 0.0.0.0 --bind-port 50051 --scheduler-host ballista-scheduler"
+    image: apache/arrow-ballista-executor:0.8.0
+    command: "--bind-host 0.0.0.0 --bind-port 50051 --scheduler-host ballista-scheduler"
     ports:
       - "50051:50051"
     environment:
@@ -95,3 +99,5 @@ ballista-executor_1   | [2021-08-28T15:55:22Z INFO  ballista_executor] Ballista 
 ```
 
 The scheduler listens on port 50050 and this is the port that clients will need to connect to.
+
+The scheduler web UI is available on port 80 in the scheduler.

--- a/docs/source/user-guide/deployment/docker.md
+++ b/docs/source/user-guide/deployment/docker.md
@@ -31,7 +31,10 @@ cd arrow-datafusion
 ./dev/build-ballista-docker.sh
 ```
 
-This will create an image with the tag `ballista:0.7.0`.
+This will create the following images:
+
+- `apache/arrow-ballista-scheduler:0.8.0`
+- `apache/arrow-ballista-executor:0.8.0`
 
 ### Start a Scheduler
 
@@ -39,23 +42,27 @@ Start a scheduler using the following syntax:
 
 ```bash
 docker run --network=host \
-  -d ballista:0.7.0 \
-  /scheduler --bind-port 50050
+ -d apache/arrow-ballista-scheduler:0.8.0 \
+ --bind-port 50050
 ```
 
 Run `docker ps` to check that the process is running:
 
 ```
 $ docker ps
-CONTAINER ID   IMAGE            COMMAND                  CREATED         STATUS        PORTS     NAMES
-1f3f8b5ed93a   ballista:0.7.0   "/scheduler --bind-p…"   2 seconds ago   Up 1 second             tender_archimedes
+CONTAINER ID   IMAGE                                   COMMAND                  CREATED         STATUS        PORTS     NAMES
+8cdea4956c97   apache/arrow-ballista-scheduler:0.8.0   "/scheduler-entrypoi…"   2 seconds ago   Up 1 second             nervous_swirles
 ```
 
 Run `docker logs CONTAINER_ID` to check the output from the process:
 
 ```
-$ docker logs 1f3f8b5ed93a
-[2021-08-28T15:45:11Z INFO  ballista_scheduler] Ballista v0.7.0 Scheduler listening on 0.0.0.0:50050
+$ docker logs 8cdea4956c97
+Starting nginx to serve Ballista Scheduler web UI on port 80
+2022-09-19T13:51:34.792363Z  INFO main ThreadId(01) ballista_scheduler: Ballista v0.8.0 Scheduler listening on 0.0.0.0:50050
+2022-09-19T13:51:34.792395Z  INFO main ThreadId(01) ballista_scheduler: Starting Scheduler grpc server with task scheduling policy of PullStaged
+2022-09-19T13:51:34.792494Z  INFO main ThreadId(01) ballista_scheduler::scheduler_server::query_stage_scheduler: Starting QueryStageScheduler
+2022-09-19T13:51:34.792581Z  INFO tokio-runtime-worker ThreadId(45) ballista_core::event_loop: Starting the event loop query_stage
 ```
 
 ### Start executors
@@ -64,27 +71,28 @@ Start one or more executor processes. Each executor process will need to listen 
 
 ```bash
 docker run --network=host \
-  -d ballista:0.7.0 \
-  /executor --external-host localhost --bind-port 50051
+  -d apache/arrow-ballista-executor:0.8.0 \
+  --external-host localhost --bind-port 50051
 ```
 
-Use `docker ps` to check that both the scheduer and executor(s) are now running:
+Use `docker ps` to check that both the scheduler and executor(s) are now running:
 
 ```
 $ docker ps
-CONTAINER ID   IMAGE            COMMAND                  CREATED          STATUS          PORTS     NAMES
-7c6941bb8dc0   ballista:0.7.0   "/executor --externa…"   3 seconds ago    Up 2 seconds              tender_goldberg
-1f3f8b5ed93a   ballista:0.7.0   "/scheduler --bind-p…"   50 seconds ago   Up 49 seconds             tender_archimedes
+CONTAINER ID   IMAGE                                   COMMAND                  CREATED         STATUS         PORTS     NAMES
+f0b21f6b5050   apache/arrow-ballista-executor:0.8.0    "/executor-entrypoin…"   2 seconds ago   Up 1 second              relaxed_goldberg
+8cdea4956c97   apache/arrow-ballista-scheduler:0.8.0   "/scheduler-entrypoi…"   2 minutes ago   Up 2 minutes             nervous_swirles
 ```
 
 Use `docker logs CONTAINER_ID` to check the output from the executor(s):
 
 ```
-$ docker logs 7c6941bb8dc0
-[2021-08-28T15:45:58Z INFO  ballista_executor] Running with config:
-[2021-08-28T15:45:58Z INFO  ballista_executor] work_dir: /tmp/.tmpeyEM76
-[2021-08-28T15:45:58Z INFO  ballista_executor] concurrent_tasks: 4
-[2021-08-28T15:45:58Z INFO  ballista_executor] Ballista v0.7.0 Rust Executor listening on 0.0.0.0:50051
+$ docker logs f0b21f6b5050
+2022-09-19T13:54:10.806231Z  INFO main ThreadId(01) ballista_executor: Running with config:
+2022-09-19T13:54:10.806261Z  INFO main ThreadId(01) ballista_executor: work_dir: /tmp/.tmp5BdxT2
+2022-09-19T13:54:10.806265Z  INFO main ThreadId(01) ballista_executor: concurrent_tasks: 48
+2022-09-19T13:54:10.807454Z  INFO tokio-runtime-worker ThreadId(49) ballista_executor: Ballista v0.8.0 Rust Executor Flight Server listening on 0.0.0.0:50051
+2022-09-19T13:54:10.807467Z  INFO tokio-runtime-worker ThreadId(46) ballista_executor::execution_loop: Starting poll work loop with scheduler
 ```
 
 ### Using etcd as backing store
@@ -96,11 +104,11 @@ to launch the scheduler with this option enabled.
 
 ```bash
 docker run --network=host \
-  -d ballista:0.7.0 \
-  /scheduler --bind-port 50050 \
+  -d apache/arrow-ballista-scheduler:0.8.0 \
+  --bind-port 50050 \
   --config-backend etcd \
   --etcd-urls etcd:2379
 ```
 
-Please refer to the [etcd](https://etcd.io/) web site for installation instructions. Etcd version 3.4.9 or later is
+Please refer to the [etcd](https://etcd.io/) website for installation instructions. Etcd version 3.4.9 or later is
 recommended.

--- a/docs/source/user-guide/deployment/kubernetes.md
+++ b/docs/source/user-guide/deployment/kubernetes.md
@@ -60,15 +60,20 @@ cd arrow-ballista
 ./dev/build-ballista-docker.sh
 ```
 
-This will create an image with the tag `ballista:0.7.0`.
+This will create the following images:
+
+- `apache/arrow-ballista-scheduler:0.8.0`
+- `apache/arrow-ballista-executor:0.8.0`
 
 ## Publishing your images
 
 Once the images have been built, you can retag them and can push them to your favourite docker registry.
 
 ```bash
-docker tag ballista:0.7.0 <your-repo>/ballista:0.7.0
-docker push <your-repo>/ballista:0.7.0
+docker tag apache/arrow-ballista-scheduler:0.8.0 <your-repo>/arrow-ballista-scheduler:0.8.0
+docker tag apache/arrow-ballista-executor:0.8.0 <your-repo>/arrow-ballista-executor:0.8.0
+docker push <your-repo>/arrow-ballista-scheduler:0.8.0
+docker push <your-repo>/arrow-ballista-executor:0.8.0
 ```
 
 ## Create Persistent Volume and Persistent Volume Claim
@@ -134,6 +139,8 @@ spec:
   ports:
     - port: 50050
       name: scheduler
+    - port: 80
+      name: scheduler-ui
   selector:
     app: ballista-scheduler
 ---
@@ -154,12 +161,13 @@ spec:
     spec:
       containers:
         - name: ballista-scheduler
-          image: <your-repo>/ballista:0.7.0
-          command: ["/scheduler"]
+          image: <your-repo>/arrow-ballista-scheduler:0.8.0
           args: ["--bind-port=50050"]
           ports:
             - containerPort: 50050
               name: flight
+            - containerPort: 80
+              name: webui
           volumeMounts:
             - mountPath: /mnt
               name: data
@@ -185,8 +193,7 @@ spec:
     spec:
       containers:
         - name: ballista-executor
-          image: <your-repo>/ballista:0.7.0
-          command: ["/executor"]
+          image: <your-repo>/arrow-ballista-executor:0.8.0
           args:
             - "--bind-port=50051"
             - "--scheduler-host=ballista-scheduler"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-ballista/issues/11

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

With this PR, I can connect to the scheduler web UI. The only functionality so far is being able to see a list of executors but with this in place we can iterate on adding new functionality such as viewing jobs, stages, and metrics.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Create separate images for scheduler vs executor
- Prefix image names with `apache/arrow-`
- Include scheduler UI in scheduler image
- Use `ENTRYPOINT` instead of `CMD` inside scheduler and executor images

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
