### PR TITLE
Fix integration test for M1 Mac

### DIFF
--- a/dev/build-ballista-docker.sh
+++ b/dev/build-ballista-docker.sh
@@ -21,4 +21,4 @@ set -e
 
 . ./dev/build-set-env.sh
 docker build -t ballista-base:$BALLISTA_VERSION -f dev/docker/ballista-base.dockerfile .
-docker build -t ballista:$BALLISTA_VERSION -f dev/docker/ballista.dockerfile .
+docker build --build-arg VERSION=$BALLISTA_VERSION -t ballista:$BALLISTA_VERSION -f dev/docker/ballista.dockerfile .

--- a/dev/docker/ballista.dockerfile
+++ b/dev/docker/ballista.dockerfile
@@ -22,7 +22,7 @@
 # as a mounted directory.
 
 ARG RELEASE_FLAG=--release
-ARG VERSION=0.7.0
+ARG VERSION=0.8.0
 
 FROM ballista-base:$VERSION AS base
 WORKDIR /tmp/ballista

--- a/dev/integration-tests.sh
+++ b/dev/integration-tests.sh
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 set -e
+export DOCKER_DEFAULT_PLATFORM=x86_64
 ./dev/build-ballista-docker.sh
 pushd benchmarks
 ./tpch-gen.sh


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #https://github.com/apache/arrow-ballista/issues/234

 # Rationale for this change
Docker on M1 Mac leverages aarch64 architecture by default. The current docker build is based on the x86_64 architecture and fails in case of aarch64

# What changes are included in this PR?
- Force docker to use x86_64 architecture for docker build
- Fixes minor issues with respect to Ballista base docker version reference
