### PR TITLE
Support different CPU architectures

### DIFF
--- a/dev/build-ballista-docker.sh
+++ b/dev/build-ballista-docker.sh
@@ -21,4 +21,4 @@ set -e
 
 . ./dev/build-set-env.sh
 docker build -t ballista-base:$BALLISTA_VERSION -f dev/docker/ballista-base.dockerfile .
-docker build -t ballista:$BALLISTA_VERSION -f dev/docker/ballista.dockerfile .
+docker build --build-arg VERSION=$BALLISTA_VERSION -t ballista:$BALLISTA_VERSION -f dev/docker/ballista.dockerfile .

--- a/dev/docker/ballista-base.dockerfile
+++ b/dev/docker/ballista-base.dockerfile
@@ -42,15 +42,16 @@ ARG OPENSSL_VERSION=1.1.1b
 # component. It's possible that this will cause bizarre and terrible things to
 # happen. There may be "sanitized" header
 RUN echo "Building OpenSSL" && \
+    CPU_ARCH=`uname -m` && \
     ls /usr/include/linux && \
     mkdir -p /usr/local/musl/include && \
     ln -s /usr/include/linux /usr/local/musl/include/linux && \
-    ln -s /usr/include/x86_64-linux-gnu/asm /usr/local/musl/include/asm && \
+    ln -s /usr/include/${CPU_ARCH}-linux-gnu/asm /usr/local/musl/include/asm && \
     ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic && \
     cd /tmp && \
     curl -LO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && \
     tar xvzf "openssl-$OPENSSL_VERSION.tar.gz" && cd "openssl-$OPENSSL_VERSION" && \
-    env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 && \
+    env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-${CPU_ARCH} && \
     env C_INCLUDE_PATH=/usr/local/musl/include/ make depend && \
     env C_INCLUDE_PATH=/usr/local/musl/include/ make && \
     make install && \
@@ -91,7 +92,8 @@ ENV OPENSSL_DIR=/usr/local/musl/ \
 # The content copied mentioned in the NOTE above ends here.
 
 ## Download the target for static linking.
-RUN rustup target add x86_64-unknown-linux-musl
+RUN CPU_ARCH=`uname -m` && \
+    rustup target add $CPU_ARCH-unknown-linux-musl
 RUN cargo install cargo-build-deps
 
 # prepare toolchain

--- a/dev/docker/ballista.dockerfile
+++ b/dev/docker/ballista.dockerfile
@@ -51,7 +51,7 @@ WORKDIR /tmp/protoc
 
 RUN CPU_ARCH=`uname -m` && \
   if [ $CPU_ARCH=="aarch64" ]; then CPU_ARCH="aarch_64"; fi && \
-  export PROTO_ZIP="protoc-${PROTOC_VERSION}-linux-${ARCH}.zip" && \
+  export PROTO_ZIP="protoc-${PROTOC_VERSION}-linux-${CPU_ARCH}.zip" && \
   curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTO_ZIP && \
   unzip $PROTO_ZIP
 

--- a/dev/docker/ballista.dockerfile
+++ b/dev/docker/ballista.dockerfile
@@ -50,7 +50,7 @@ RUN mkdir /tmp/protoc
 WORKDIR /tmp/protoc
 
 RUN CPU_ARCH=`uname -m` && \
-  if [ $CPU_ARCH=="aarch64" ]; then CPU_ARCH="aarch_64"; fi && \
+  if [ "$CPU_ARCH" = "aarch64" ]; then CPU_ARCH="aarch_64"; fi && \
   export PROTO_ZIP="protoc-${PROTOC_VERSION}-linux-${CPU_ARCH}.zip" && \
   curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTO_ZIP && \
   unzip $PROTO_ZIP

--- a/dev/docker/ballista.dockerfile
+++ b/dev/docker/ballista.dockerfile
@@ -22,7 +22,7 @@
 # as a mounted directory.
 
 ARG RELEASE_FLAG=--release
-ARG VERSION=0.7.0
+ARG VERSION=0.8.0
 
 FROM ballista-base:$VERSION AS base
 WORKDIR /tmp/ballista

--- a/dev/docker/ballista.dockerfile
+++ b/dev/docker/ballista.dockerfile
@@ -49,7 +49,9 @@ ARG PROTOC_VERSION=21.4
 RUN mkdir /tmp/protoc
 WORKDIR /tmp/protoc
 
-RUN export PROTO_ZIP="protoc-${PROTOC_VERSION}-linux-x86_64.zip" && \
+RUN CPU_ARCH=`uname -m` && \
+  if [ $CPU_ARCH=="aarch64" ]; then CPU_ARCH="aarch_64"; fi && \
+  export PROTO_ZIP="protoc-${PROTOC_VERSION}-linux-${ARCH}.zip" && \
   curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTO_ZIP && \
   unzip $PROTO_ZIP
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
M1 Macs leverage aarch64 cpu architecture. The docker build/integration tests can be executed by forcing the docker to use x86_64. But due to the emulation the integration tests are taking over 30mins. This PR adds supports for docker build in aarch64 architecture

# What changes are included in this PR?
- Support for aarch64/arm64 CPU architecture
