### PR TITLE
Also run yarn build to catch JavaScript errors in CI

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: TypeScript Release Build
+
+on:
+  # always trigger
+  push:
+  pull_request:
+
+jobs:
+  yarn-build:
+    name: Yarn build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          apt-get install -y nodejs npm
+          npm install -g yarn
+
+      - name: Run yarn build
+        run: |
+          cd ballista/ui/scheduler
+          yarn install
+          yarn build


### PR DESCRIPTION
# Which issue does this PR close?

Closes #270.

 # Rationale for this change

Treat the yarn build as a first-class citizen.

# What changes are included in this PR?

A CI job to build yarn.

# Are there any user-facing changes?

TypeScript code should always at least compile if not work.