### PR TITLE
Add support for SortPreservingMergeExec; fix LIMIT bug

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -375,6 +375,8 @@ message LocalLimitExecNode {
 message SortExecNode {
   PhysicalPlanNode input = 1;
   repeated PhysicalExprNode expr = 2;
+  // Maximum number of highest/lowest rows to fetch; negative means no limit
+  int64 fetch = 3;
 }
 
 message SortPreservingMergeExecNode {

--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -79,6 +79,7 @@ message PhysicalPlanNode {
     PhysicalExtensionNode extension = 21;
     UnionExecNode union = 22;
     ExplainExecNode explain = 23;
+    SortPreservingMergeExecNode sort_preserving_merge = 24;
   }
 }
 
@@ -360,8 +361,10 @@ message ShuffleReaderPartition {
 
 message GlobalLimitExecNode {
   PhysicalPlanNode input = 1;
+  // The number of rows to skip before fetch
   uint32 skip = 2;
-  uint32 fetch = 3;
+  // Maximum number of rows to fetch; negative means no limit
+  int64 fetch = 3;
 }
 
 message LocalLimitExecNode {
@@ -370,6 +373,11 @@ message LocalLimitExecNode {
 }
 
 message SortExecNode {
+  PhysicalPlanNode input = 1;
+  repeated PhysicalExprNode expr = 2;
+}
+
+message SortPreservingMergeExecNode {
   PhysicalPlanNode input = 1;
   repeated PhysicalExprNode expr = 2;
 }

--- a/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -46,6 +46,7 @@ use datafusion::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::windows::{create_window_expr, WindowAggExec};
 use datafusion::physical_plan::{
@@ -240,7 +241,7 @@ impl AsExecutionPlan for PhysicalPlanNode {
             PhysicalPlanType::GlobalLimit(limit) => {
                 let input: Arc<dyn ExecutionPlan> =
                     into_physical_plan!(limit.input, registry, runtime, extension_codec)?;
-                let fetch = if limit.fetch > 0 {
+                let fetch = if limit.fetch >= 0 {
                     Some(limit.fetch as usize)
                 } else {
                     None
@@ -642,6 +643,47 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(Arc::new(SortExec::try_new(exprs, input, None)?))
             }
+            PhysicalPlanType::SortPreservingMerge(sort) => {
+                let input: Arc<dyn ExecutionPlan> =
+                    into_physical_plan!(sort.input, registry, runtime, extension_codec)?;
+                let exprs = sort
+                    .expr
+                    .iter()
+                    .map(|expr| {
+                        let expr = expr.expr_type.as_ref().ok_or_else(|| {
+                            proto_error(format!(
+                                "physical_plan::from_proto() Unexpected expr {:?}",
+                                self
+                            ))
+                        })?;
+                        if let protobuf::physical_expr_node::ExprType::Sort(sort_expr) = expr {
+                            let expr = sort_expr
+                                .expr
+                                .as_ref()
+                                .ok_or_else(|| {
+                                    proto_error(format!(
+                                        "physical_plan::from_proto() Unexpected sort expr {:?}",
+                                        self
+                                    ))
+                                })?
+                                .as_ref();
+                            Ok(PhysicalSortExpr {
+                                expr: parse_physical_expr(expr,registry, input.schema().as_ref())?,
+                                options: SortOptions {
+                                    descending: !sort_expr.asc,
+                                    nulls_first: sort_expr.nulls_first,
+                                },
+                            })
+                        } else {
+                            Err(BallistaError::General(format!(
+                                "physical_plan::from_proto() {:?}",
+                                self
+                            )))
+                        }
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Arc::new(SortPreservingMergeExec::new(exprs, input)))
+            }
             PhysicalPlanType::Unresolved(unresolved_shuffle) => {
                 let schema = Arc::new(convert_required!(unresolved_shuffle.schema)?);
                 Ok(Arc::new(UnresolvedShuffleExec {
@@ -739,7 +781,10 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     protobuf::GlobalLimitExecNode {
                         input: Some(Box::new(input)),
                         skip: limit.skip() as u32,
-                        fetch: *limit.fetch().unwrap_or(&0) as u32,
+                        fetch: match limit.fetch() {
+                            Some(n) => *n as i64,
+                            _ => -1, // no limit
+                        },
                     },
                 ))),
             })
@@ -1121,21 +1166,58 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     protobuf::UnionExecNode { inputs },
                 )),
             })
-        } else {
-            let mut buf: Vec<u8> = vec![];
-            extension_codec.try_encode(plan_clone.clone(), &mut buf)?;
-
-            let inputs: Vec<PhysicalPlanNode> = plan_clone
-                .children()
-                .into_iter()
-                .map(|i| PhysicalPlanNode::try_from_physical_plan(i, extension_codec))
-                .collect::<Result<_, BallistaError>>()?;
-
+        } else if let Some(exec) = plan.downcast_ref::<SortPreservingMergeExec>() {
+            let input = protobuf::PhysicalPlanNode::try_from_physical_plan(
+                exec.input().to_owned(),
+                extension_codec,
+            )?;
+            let expr = exec
+                .expr()
+                .iter()
+                .map(|expr| {
+                    let sort_expr = Box::new(protobuf::PhysicalSortExprNode {
+                        expr: Some(Box::new(expr.expr.to_owned().try_into()?)),
+                        asc: !expr.options.descending,
+                        nulls_first: expr.options.nulls_first,
+                    });
+                    Ok(protobuf::PhysicalExprNode {
+                        expr_type: Some(protobuf::physical_expr_node::ExprType::Sort(
+                            sort_expr,
+                        )),
+                    })
+                })
+                .collect::<Result<Vec<_>, BallistaError>>()?;
             Ok(protobuf::PhysicalPlanNode {
-                physical_plan_type: Some(PhysicalPlanType::Extension(
-                    PhysicalExtensionNode { node: buf, inputs },
+                physical_plan_type: Some(PhysicalPlanType::SortPreservingMerge(
+                    Box::new(protobuf::SortPreservingMergeExecNode {
+                        input: Some(Box::new(input)),
+                        expr,
+                    }),
                 )),
             })
+        } else {
+            let mut buf: Vec<u8> = vec![];
+            match extension_codec.try_encode(plan_clone.clone(), &mut buf) {
+                Ok(_) => {
+                    let inputs: Vec<PhysicalPlanNode> = plan_clone
+                        .children()
+                        .into_iter()
+                        .map(|i| {
+                            PhysicalPlanNode::try_from_physical_plan(i, extension_codec)
+                        })
+                        .collect::<Result<_, BallistaError>>()?;
+
+                    Ok(protobuf::PhysicalPlanNode {
+                        physical_plan_type: Some(PhysicalPlanType::Extension(
+                            PhysicalExtensionNode { node: buf, inputs },
+                        )),
+                    })
+                }
+                Err(e) => Err(BallistaError::Internal(format!(
+                    "Unsupported plan and extension codec failed with [{}]. Plan: {:?}",
+                    e, plan_clone
+                ))),
+            }
         }
     }
 }
@@ -1336,6 +1418,15 @@ mod roundtrip_tests {
             Arc::new(EmptyExec::new(false, Arc::new(Schema::empty()))),
             0,
             Some(25),
+        )))
+    }
+
+    #[test]
+    fn roundtrip_global_skip_no_limit() -> Result<()> {
+        roundtrip_test(Arc::new(GlobalLimitExec::new(
+            Arc::new(EmptyExec::new(false, Arc::new(Schema::empty()))),
+            10,
+            None, // no limit
         )))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-ballista/issues/300

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Queries with `LIMIT` may now include `SortPreservingMergeExec` and we did not support that in ballista.proto

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add serde code for `SortPreservingMergeExec`
- Improve error when serde code finds an unsupported exec
- Fixed a bug with encoding `GlobalLimitExec`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
