### PR TITLE
Add REST API to generate DOT graph for individual query stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,75 +17,63 @@
   under the License.
 -->
 
-# Ballista: Distributed SQL Query Engine, built on Apache Arrow
+# Ballista: Distributed Compute with Rust, Apache Arrow, and DataFusion
 
-Ballista is a distributed SQL query engine powered by the Rust implementation of [Apache Arrow](arrow) and
-[DataFusion](datafusion). 
+Ballista is a distributed SQL query engine primarily implemented in Rust, and powered by Apache Arrow and
+DataFusion. It is built on an architecture that allows other programming languages (such as Python, C++, and
+Java) to be supported as first-class citizens without paying a penalty for serialization costs.
 
-If you are looking for documentation for a released version of Ballista, please refer to the 
-[Ballista User Guide](user-guide).
+The foundational technologies in Ballista are:
 
-## Overview
+- [Apache Arrow](https://arrow.apache.org/) memory model and compute kernels for efficient processing of data.
+- [DataFusion Query Engine](https://github.com/apache/arrow-datafusion) for query execution
+- [Apache Arrow Flight Protocol](https://arrow.apache.org/blog/2019/10/13/introducing-arrow-flight/) for efficient
+  data transfer between processes.
+- [Google Protocol Buffers](https://developers.google.com/protocol-buffers) for serializing query plans, with [plans to
+  eventually use substrait.io here](https://github.com/apache/arrow-ballista/issues/32).
 
 Ballista implements a similar design to Apache Spark (particularly Spark SQL), but there are some key differences:
 
-- The choice of Rust as the main execution language avoids the overhead of GC pauses and results in deterministic 
-  processing times.
+- The choice of Rust as the main execution language avoids the overhead of GC pauses.
 - Ballista is designed from the ground up to use columnar data, enabling a number of efficiencies such as vectorized
-  processing (SIMD) and efficient compression. Although Spark does have some columnar support, it is still
+  processing (SIMD and GPU) and efficient compression. Although Spark does have some columnar support, it is still
   largely row-based today.
 - The combination of Rust and Arrow provides excellent memory efficiency and memory usage can be 5x - 10x lower than
   Apache Spark in some cases, which means that more processing can fit on a single node, reducing the overhead of
   distributed compute.
-- The use of Apache Arrow as the memory model and network protocol means that data can be exchanged efficiently between 
-  executors using the [Flight Protocol](flight), and between clients and schedulers/executors using the 
-  [Flight SQL Protocol](flight-sql)
+- The use of Apache Arrow as the memory model and network protocol means that data can be exchanged between executors
+  in any programming language with minimal serialization overhead.
 
-## Features
+Ballista can be deployed as a standalone cluster and also supports [Kubernetes](https://kubernetes.io/). In either
+case, the scheduler can be configured to use [etcd](https://etcd.io/) as a backing store to (eventually) provide
+redundancy in the case of a scheduler failing.
 
-- Supports HDFS as well as cloud object stores. S3 is supported today and GCS and Azure support is planned.
-- DataFrame and SQL APIs available from Python and Rust.
-- Clients can connect to a Ballista cluster using [Flight SQL](flight-sql).
-- JDBC support via Arrow Flight SQL JDBC Driver
-- Scheduler web interface and REST UI for monitoring query progress and viewing query plans and metrics.
-- Support for Docker, Docker Compose, and Kubernetes deployment, as well as manual deployment on bare metal. 
+# Project Status and Roadmap
+
+Ballista is currently a proof-of-concept and provides batch execution of SQL queries. Although it is already capable of
+executing complex queries, it is not yet scalable or robust.
+
+There is an excellent discussion in https://github.com/apache/arrow-ballista/issues/30 about the future of the project
+and we encourage you to participate and add your feedback there if you are interested in using or contributing to
+Ballista.
+
+The current initiatives being considered are:
+
+- Continue to improve the current batch-based execution
+- Add support for low-latency query execution based on a streaming model
+- Adopt [substrait.io](https://substrait.io/) to allow other query engines to be integrated
 
 # Getting Started
 
 The easiest way to get started is to run one of the standalone or distributed [examples](./examples/README.md). After
 that, refer to the [Getting Started Guide](ballista/rust/client/README.md).
 
-## Project Status
-
-A common question is whether Ballista is production-ready. The answer is "it depends". We encourage you to try 
-Ballista for your use case and make your own determination.
-
-Ballista supports a wide range of SQL, including CTEs, Joins, and Subqueries and can execute complex queries at scale.
-
-## Roadmap
-
-There is an excellent discussion in https://github.com/apache/arrow-ballista/issues/30 about the future of the project
-and we encourage you to participate and add your feedback there if you are interested in using or contributing to
-Ballista.
-
-The current focus is on the following items:
-
-- Improve stability and scalability
-- Add support for low-latency query execution based on a streaming model
-- Move towards Morsel-based scheduling
-
 ## Architecture Overview
 
-There are currently no up-to-date architecture documents available. You can get a general overview of the architecture 
-by watching the [Ballista: Distributed Compute with Rust and Apache Arrow](ballista-talk) talk from the New York Open 
-Statistical Programming Meetup (Feb 2021).
+- Refer to the [developer documentation](docs/developer) for the [Architecture Overview](/docs/developer/architecture.md)
+- Watch the [Ballista: Distributed Compute with Rust and Apache Arrow](https://www.youtube.com/watch?v=ZZHQaOap9pQ)
+  talk from the New York Open Statistical Programming Meetup (Feb 2021)
 
 ## Contribution Guide
 
 Please see [Contribution Guide](CONTRIBUTING.md) for information about contributing to DataFusion.
-
-[arrow]: https://arrow.apache.org/
-[datafusion]: https://github.com/apache/arrow-datafusion
-[flight]: https://arrow.apache.org/blog/2019/10/13/introducing-arrow-flight/
-[flight-sql]: https://arrow.apache.org/blog/2022/02/16/introducing-arrow-flight-sql/
-[ballista-talk]: https://www.youtube.com/watch?v=ZZHQaOap9pQ

--- a/ballista/rust/scheduler/src/api/handlers.rs
+++ b/ballista/rust/scheduler/src/api/handlers.rs
@@ -145,7 +145,7 @@ pub(crate) async fn get_jobs<T: AsLogicalPlan, U: AsExecutionPlan>(
                 ((job.completed_stages as f32 / job.num_stages as f32) * 100_f32) as u8;
             JobResponse {
                 job_id: job.job_id.to_string(),
-                job_name: job.job_name.to_owned().unwrap_or_default(),
+                job_name: job.job_name.to_string(),
                 job_status,
                 num_stages: job.num_stages,
                 completed_stages: job.completed_stages,
@@ -167,35 +167,27 @@ pub(crate) async fn get_query_stages<T: AsLogicalPlan, U: AsExecutionPlan>(
     data_server: SchedulerServer<T, U>,
     job_id: String,
 ) -> Result<impl warp::Reply, Rejection> {
-    let maybe_graph = data_server
+    if let Some(graph) = data_server
         .state
         .task_manager
         .get_job_execution_graph(&job_id)
         .await
-        .map_err(|_| warp::reject())?;
-
-    match maybe_graph {
-        Some(graph) => Ok(warp::reply::json(&QueryStagesResponse {
+        .map_err(|_| warp::reject())?
+    {
+        Ok(warp::reply::json(&QueryStagesResponse {
             stages: graph
                 .stages()
                 .iter()
                 .map(|(id, stage)| {
                     let mut summary = QueryStageSummary {
                         stage_id: id.to_string(),
-                        stage_status: "".to_string(),
+                        stage_status: stage.variant_name().to_string(),
                         input_rows: 0,
                         output_rows: 0,
                         elapsed_compute: "".to_string(),
                     };
                     match stage {
-                        ExecutionStage::UnResolved(_) => {
-                            summary.stage_status = "Unresolved".to_string();
-                        }
-                        ExecutionStage::Resolved(_) => {
-                            summary.stage_status = "Resolved".to_string();
-                        }
                         ExecutionStage::Running(running_stage) => {
-                            summary.stage_status = "Running".to_string();
                             summary.input_rows = running_stage
                                 .stage_metrics
                                 .as_ref()
@@ -213,7 +205,6 @@ pub(crate) async fn get_query_stages<T: AsLogicalPlan, U: AsExecutionPlan>(
                                 .unwrap_or_default();
                         }
                         ExecutionStage::Successful(completed_stage) => {
-                            summary.stage_status = "Completed".to_string();
                             summary.input_rows = get_combined_count(
                                 &completed_stage.stage_metrics,
                                 "input_rows",
@@ -225,15 +216,14 @@ pub(crate) async fn get_query_stages<T: AsLogicalPlan, U: AsExecutionPlan>(
                             summary.elapsed_compute =
                                 get_elapsed_compute_nanos(&completed_stage.stage_metrics);
                         }
-                        ExecutionStage::Failed(_) => {
-                            summary.stage_status = "Failed".to_string();
-                        }
+                        _ => {}
                     }
                     summary
                 })
                 .collect(),
-        })),
-        _ => Ok(warp::reply::json(&QueryStagesResponse { stages: vec![] })),
+        }))
+    } else {
+        Ok(warp::reply::json(&QueryStagesResponse { stages: vec![] }))
     }
 }
 
@@ -273,16 +263,16 @@ pub(crate) async fn get_job_dot_graph<T: AsLogicalPlan, U: AsExecutionPlan>(
     data_server: SchedulerServer<T, U>,
     job_id: String,
 ) -> Result<String, Rejection> {
-    let maybe_graph = data_server
+    if let Some(graph) = data_server
         .state
         .task_manager
         .get_job_execution_graph(&job_id)
         .await
-        .map_err(|_| warp::reject())?;
-
-    match maybe_graph {
-        Some(graph) => ExecutionGraphDot::generate(graph).map_err(|_| warp::reject()),
-        _ => Ok("Not Found".to_string()),
+        .map_err(|_| warp::reject())?
+    {
+        ExecutionGraphDot::generate(graph).map_err(|_| warp::reject())
+    } else {
+        Ok("Not Found".to_string())
     }
 }
 
@@ -292,17 +282,17 @@ pub(crate) async fn get_query_stage_dot_graph<T: AsLogicalPlan, U: AsExecutionPl
     job_id: String,
     stage_id: usize,
 ) -> Result<String, Rejection> {
-    let maybe_graph = data_server
+    if let Some(graph) = data_server
         .state
         .task_manager
         .get_job_execution_graph(&job_id)
         .await
-        .map_err(|_| warp::reject())?;
-
-    match maybe_graph {
-        Some(graph) => ExecutionGraphDot::generate_for_query_stage(graph, stage_id)
-            .map_err(|_| warp::reject()),
-        _ => Ok("Not Found".to_string()),
+        .map_err(|_| warp::reject())?
+    {
+        ExecutionGraphDot::generate_for_query_stage(graph, stage_id)
+            .map_err(|_| warp::reject())
+    } else {
+        Ok("Not Found".to_string())
     }
 }
 

--- a/ballista/rust/scheduler/src/api/mod.rs
+++ b/ballista/rust/scheduler/src/api/mod.rs
@@ -100,6 +100,14 @@ pub fn get_routes<T: AsLogicalPlan + Clone, U: 'static + AsExecutionPlan>(
     let route_job_dot = warp::path!("api" / "job" / String / "dot")
         .and(with_data_server(scheduler_server.clone()))
         .and_then(|job_id, data_server| handlers::get_job_dot_graph(data_server, job_id));
+
+    let route_query_stage_dot =
+        warp::path!("api" / "job" / String / "stage" / usize / "dot")
+            .and(with_data_server(scheduler_server.clone()))
+            .and_then(|job_id, stage_id, data_server| {
+                handlers::get_query_stage_dot_graph(data_server, job_id, stage_id)
+            });
+
     let route_job_dot_svg = warp::path!("api" / "job" / String / "dot_svg")
         .and(with_data_server(scheduler_server))
         .and_then(|job_id, data_server| handlers::get_job_svg_graph(data_server, job_id));
@@ -108,6 +116,7 @@ pub fn get_routes<T: AsLogicalPlan + Clone, U: 'static + AsExecutionPlan>(
         .or(route_jobs)
         .or(route_job_summary)
         .or(route_job_dot)
+        .or(route_query_stage_dot)
         .or(route_job_dot_svg);
     routes.boxed()
 }

--- a/ballista/rust/scheduler/src/flight_sql.rs
+++ b/ballista/rust/scheduler/src/flight_sql.rs
@@ -295,8 +295,9 @@ impl FlightSqlServiceImpl {
         plan: &LogicalPlan,
     ) -> Result<String, Status> {
         let job_id = self.server.state.task_manager.generate_job_id();
+        let job_name = format!("Flight SQL job {}", job_id);
         self.server
-            .submit_job(&job_id, None, ctx, plan)
+            .submit_job(&job_id, &job_name, ctx, plan)
             .await
             .map_err(|e| {
                 let msg =

--- a/ballista/rust/scheduler/src/scheduler_server/event.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/event.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 pub enum QueryStageSchedulerEvent {
     JobQueued {
         job_id: String,
-        job_name: Option<String>,
+        job_name: String,
         session_ctx: Arc<SessionContext>,
         plan: Box<LogicalPlan>,
     },

--- a/ballista/rust/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/grpc.rs
@@ -424,9 +424,13 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             debug!("Received plan for execution: {:?}", plan);
 
             let job_id = self.state.task_manager.generate_job_id();
-            let job_name = config.settings().get(BALLISTA_JOB_NAME);
+            let job_name = config
+                .settings()
+                .get(BALLISTA_JOB_NAME)
+                .cloned()
+                .unwrap_or_default();
 
-            self.submit_job(&job_id, job_name.cloned(), session_ctx, &plan)
+            self.submit_job(&job_id, &job_name, session_ctx, &plan)
                 .await
                 .map_err(|e| {
                     let msg =

--- a/ballista/rust/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/mod.rs
@@ -141,7 +141,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
     pub(crate) async fn submit_job(
         &self,
         job_id: &str,
-        job_name: Option<String>,
+        job_name: &str,
         ctx: Arc<SessionContext>,
         plan: &LogicalPlan,
     ) -> Result<()> {
@@ -149,7 +149,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
             .get_sender()?
             .post_event(QueryStageSchedulerEvent::JobQueued {
                 job_id: job_id.to_owned(),
-                job_name,
+                job_name: job_name.to_owned(),
                 session_ctx: ctx,
                 plan: Box::new(plan.clone()),
             })
@@ -339,7 +339,7 @@ mod test {
         // Submit job
         scheduler
             .state
-            .submit_job(job_id, None, ctx, &plan)
+            .submit_job(job_id, "", ctx, &plan)
             .await
             .expect("submitting plan");
 
@@ -444,7 +444,7 @@ mod test {
 
         let job_id = "job";
 
-        scheduler.state.submit_job(job_id, None, ctx, &plan).await?;
+        scheduler.state.submit_job(job_id, "", ctx, &plan).await?;
 
         // Complete tasks that are offered through scheduler events
         loop {
@@ -593,7 +593,7 @@ mod test {
 
         let job_id = "job";
 
-        scheduler.state.submit_job(job_id, None, ctx, &plan).await?;
+        scheduler.state.submit_job(job_id, "", ctx, &plan).await?;
 
         let available_tasks = scheduler
             .state
@@ -729,7 +729,7 @@ mod test {
         let job_id = "job";
 
         // This should fail when we try and create the physical plan
-        scheduler.submit_job(job_id, None, ctx, &plan).await?;
+        scheduler.submit_job(job_id, "", ctx, &plan).await?;
 
         let scheduler = scheduler.clone();
 

--- a/ballista/rust/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -80,7 +80,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 let state = self.state.clone();
                 tokio::spawn(async move {
                     let event = if let Err(e) = state
-                        .submit_job(&job_id, job_name, session_ctx, &plan)
+                        .submit_job(&job_id, &job_name, session_ctx, &plan)
                         .await
                     {
                         let msg = format!("Error planning job {}: {:?}", job_id, e);

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -104,8 +104,8 @@ pub struct ExecutionGraph {
     scheduler_id: String,
     /// ID for this job
     job_id: String,
-    /// Optional job name
-    job_name: Option<String>,
+    /// Job name, can be empty string
+    job_name: String,
     /// Session ID for this job
     session_id: String,
     /// Status of this job
@@ -136,7 +136,7 @@ impl ExecutionGraph {
     pub fn new(
         scheduler_id: &str,
         job_id: &str,
-        job_name: Option<String>,
+        job_name: &str,
         session_id: &str,
         plan: Arc<dyn ExecutionPlan>,
     ) -> Result<Self> {
@@ -152,7 +152,7 @@ impl ExecutionGraph {
         Ok(Self {
             scheduler_id: scheduler_id.to_string(),
             job_id: job_id.to_string(),
-            job_name,
+            job_name: job_name.to_string(),
             session_id: session_id.to_string(),
             status: JobStatus {
                 status: Some(job_status::Status::Queued(QueuedJob {})),
@@ -169,8 +169,8 @@ impl ExecutionGraph {
         self.job_id.as_str()
     }
 
-    pub fn job_name(&self) -> Option<&String> {
-        self.job_name.as_ref()
+    pub fn job_name(&self) -> &str {
+        self.job_name.as_str()
     }
 
     pub fn session_id(&self) -> &str {
@@ -1284,11 +1284,7 @@ impl ExecutionGraph {
         Ok(ExecutionGraph {
             scheduler_id: proto.scheduler_id,
             job_id: proto.job_id,
-            job_name: if proto.job_name.is_empty() {
-                None
-            } else {
-                Some(proto.job_name)
-            },
+            job_name: proto.job_name,
             session_id: proto.session_id,
             status: proto.status.ok_or_else(|| {
                 BallistaError::Internal(
@@ -1364,7 +1360,7 @@ impl ExecutionGraph {
 
         Ok(protobuf::ExecutionGraph {
             job_id: graph.job_id,
-            job_name: graph.job_name.unwrap_or_default(),
+            job_name: graph.job_name,
             session_id: graph.session_id,
             status: Some(graph.status),
             stages,
@@ -2748,7 +2744,7 @@ mod test {
 
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
-        ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap()
+        ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap()
     }
 
     async fn test_two_aggregations_plan(partition: usize) -> ExecutionGraph {
@@ -2776,7 +2772,7 @@ mod test {
 
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
-        ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap()
+        ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap()
     }
 
     async fn test_coalesce_plan(partition: usize) -> ExecutionGraph {
@@ -2799,7 +2795,7 @@ mod test {
 
         let plan = ctx.create_physical_plan(&optimized_plan).await.unwrap();
 
-        ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap()
+        ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap()
     }
 
     async fn test_join_plan(partition: usize) -> ExecutionGraph {
@@ -2841,7 +2837,7 @@ mod test {
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
         let graph =
-            ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap();
+            ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap();
 
         println!("{:?}", graph);
 
@@ -2866,7 +2862,7 @@ mod test {
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
         let graph =
-            ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap();
+            ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap();
 
         println!("{:?}", graph);
 
@@ -2891,7 +2887,7 @@ mod test {
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
         let graph =
-            ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap();
+            ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap();
 
         println!("{:?}", graph);
 

--- a/ballista/rust/scheduler/src/state/execution_graph/execution_stage.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph/execution_stage.rs
@@ -73,6 +73,19 @@ impl Debug for ExecutionStage {
     }
 }
 
+impl ExecutionStage {
+    /// Get the query plan for this query stage
+    pub(crate) fn plan(&self) -> &dyn ExecutionPlan {
+        match self {
+            ExecutionStage::UnResolved(stage) => stage.plan.as_ref(),
+            ExecutionStage::Resolved(stage) => stage.plan.as_ref(),
+            ExecutionStage::Running(stage) => stage.plan.as_ref(),
+            ExecutionStage::Successful(stage) => stage.plan.as_ref(),
+            ExecutionStage::Failed(stage) => stage.plan.as_ref(),
+        }
+    }
+}
+
 /// For a stage whose input stages are not all completed, we say it's a unresolved stage
 #[derive(Clone)]
 pub(crate) struct UnresolvedStage {

--- a/ballista/rust/scheduler/src/state/execution_graph/execution_stage.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph/execution_stage.rs
@@ -75,7 +75,7 @@ impl Debug for ExecutionStage {
 
 impl ExecutionStage {
     /// Get the name of the variant
-    pub(crate) fn name(&self) -> &str {
+    pub(crate) fn variant_name(&self) -> &str {
         match self {
             ExecutionStage::UnResolved(_) => "Unresolved",
             ExecutionStage::Resolved(_) => "Resolved",

--- a/ballista/rust/scheduler/src/state/execution_graph/execution_stage.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph/execution_stage.rs
@@ -74,6 +74,17 @@ impl Debug for ExecutionStage {
 }
 
 impl ExecutionStage {
+    /// Get the name of the variant
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            ExecutionStage::UnResolved(_) => "Unresolved",
+            ExecutionStage::Resolved(_) => "Resolved",
+            ExecutionStage::Running(_) => "Running",
+            ExecutionStage::Successful(_) => "Successful",
+            ExecutionStage::Failed(_) => "Failed",
+        }
+    }
+
     /// Get the query plan for this query stage
     pub(crate) fn plan(&self) -> &dyn ExecutionPlan {
         match self {

--- a/ballista/rust/scheduler/src/state/execution_graph_dot.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph_dot.rs
@@ -91,7 +91,12 @@ impl ExecutionGraphDot {
             let stage = stages.get(id).unwrap(); // safe unwrap
             let stage_name = format!("stage_{}", id);
             writeln!(&mut dot, "\tsubgraph cluster{} {{", cluster)?;
-            writeln!(&mut dot, "\t\tlabel = \"Stage {} [{}]\";", id, stage.name())?;
+            writeln!(
+                &mut dot,
+                "\t\tlabel = \"Stage {} [{}]\";",
+                id,
+                stage.variant_name()
+            )?;
             stage_meta.push(write_stage_plan(&mut dot, &stage_name, stage.plan(), 0)?);
             cluster += 1;
             writeln!(&mut dot, "\t}}")?; // end of subgraph
@@ -537,6 +542,6 @@ filter_expr="]
             .await?;
         let plan = df.to_logical_plan()?;
         let plan = ctx.create_physical_plan(&plan).await?;
-        ExecutionGraph::new("scheduler_id", "job_id", "session_id", plan)
+        ExecutionGraph::new("scheduler_id", "job_id", "job_name", "session_id", plan)
     }
 }

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -251,7 +251,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
     pub(crate) async fn submit_job(
         &self,
         job_id: &str,
-        job_name: Option<String>,
+        job_name: &str,
         session_ctx: Arc<SessionContext>,
         plan: &LogicalPlan,
     ) -> Result<()> {
@@ -358,39 +358,19 @@ mod test {
         // Create 4 jobs so we have four pending tasks
         state
             .task_manager
-            .submit_job(
-                "job-1",
-                None,
-                session_ctx.session_id().as_str(),
-                plan.clone(),
-            )
+            .submit_job("job-1", "", session_ctx.session_id().as_str(), plan.clone())
             .await?;
         state
             .task_manager
-            .submit_job(
-                "job-2",
-                None,
-                session_ctx.session_id().as_str(),
-                plan.clone(),
-            )
+            .submit_job("job-2", "", session_ctx.session_id().as_str(), plan.clone())
             .await?;
         state
             .task_manager
-            .submit_job(
-                "job-3",
-                None,
-                session_ctx.session_id().as_str(),
-                plan.clone(),
-            )
+            .submit_job("job-3", "", session_ctx.session_id().as_str(), plan.clone())
             .await?;
         state
             .task_manager
-            .submit_job(
-                "job-4",
-                None,
-                session_ctx.session_id().as_str(),
-                plan.clone(),
-            )
+            .submit_job("job-4", "", session_ctx.session_id().as_str(), plan.clone())
             .await?;
 
         let executors = test_executors(1, 4);
@@ -435,12 +415,7 @@ mod test {
         // Create a job
         state
             .task_manager
-            .submit_job(
-                "job-1",
-                None,
-                session_ctx.session_id().as_str(),
-                plan.clone(),
-            )
+            .submit_job("job-1", "", session_ctx.session_id().as_str(), plan.clone())
             .await?;
 
         let executors = test_executors(1, 4);

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -95,7 +95,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     pub async fn submit_job(
         &self,
         job_id: &str,
-        job_name: Option<String>,
+        job_name: &str,
         session_id: &str,
         plan: Arc<dyn ExecutionPlan>,
     ) -> Result<()> {
@@ -142,7 +142,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             }
             jobs.push(JobOverview {
                 job_id: job_id.clone(),
-                job_name: graph.job_name().cloned(),
+                job_name: graph.job_name().to_string(),
                 status: graph.status(),
                 num_stages: graph.stage_count(),
                 completed_stages,
@@ -587,7 +587,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
 
 pub struct JobOverview {
     pub job_id: String,
-    pub job_name: Option<String>,
+    pub job_name: String,
     pub status: JobStatus,
     pub num_stages: usize,
     pub completed_stages: usize,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

For large and complex queries, I would like to be able to view the query plan for an individual query stage.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


```
http://localhost:50050/api/job/rGk0Imj/stage/2/dot
```

```
digraph G {
		stage_2_0 [shape=box, label="ShuffleWriter [3 partitions]"]
		stage_2_0_0 [shape=box, label="CoalesceBatches [batchSize=4096]"]
		stage_2_0_0_0 [shape=box, label="Filter: d_year@1 = 2000"]
		stage_2_0_0_0_0 [shape=box, label="Parquet: mnt/bigdata/tpcds/sf100-parquet/date_dim.parquet [3 files] [3 partitions]"]
		stage_2_0_0_0_0 -> stage_2_0_0_0
		stage_2_0_0_0 -> stage_2_0_0
		stage_2_0_0 -> stage_2_0
}
```

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
