### PR TITLE
Add ability to specify job name and have it show in the job listing page in the UI

### DIFF
--- a/ballista/rust/core/proto/ballista.proto
+++ b/ballista/rust/core/proto/ballista.proto
@@ -436,6 +436,7 @@ message ExecutionGraph {
   string scheduler_id = 7;
   uint32 task_id_gen = 8;
   repeated StageAttempts failed_attempts = 9;
+  string job_name = 10;
 }
 
 message StageAttempts {

--- a/ballista/rust/core/src/config.rs
+++ b/ballista/rust/core/src/config.rs
@@ -27,6 +27,7 @@ use crate::error::{BallistaError, Result};
 
 use datafusion::arrow::datatypes::DataType;
 
+pub const BALLISTA_APP_NAME: &str = "ballista.app.name";
 pub const BALLISTA_DEFAULT_SHUFFLE_PARTITIONS: &str = "ballista.shuffle.partitions";
 pub const BALLISTA_DEFAULT_BATCH_SIZE: &str = "ballista.batch.size";
 pub const BALLISTA_REPARTITION_JOINS: &str = "ballista.repartition.joins";
@@ -155,6 +156,9 @@ impl BallistaConfig {
     /// All available configuration options
     pub fn valid_entries() -> HashMap<String, ConfigEntry> {
         let entries = vec![
+            ConfigEntry::new(BALLISTA_APP_NAME.to_string(),
+                             "Sets the job name that will appear in the web user interface for any submitted jobs".to_string(),
+                             DataType::Utf8, None),
             ConfigEntry::new(BALLISTA_DEFAULT_SHUFFLE_PARTITIONS.to_string(),
                              "Sets the default number of partitions to create when repartitioning query stages".to_string(),
                              DataType::UInt16, Some("16".to_string())),

--- a/ballista/rust/core/src/config.rs
+++ b/ballista/rust/core/src/config.rs
@@ -27,7 +27,7 @@ use crate::error::{BallistaError, Result};
 
 use datafusion::arrow::datatypes::DataType;
 
-pub const BALLISTA_APP_NAME: &str = "ballista.app.name";
+pub const BALLISTA_JOB_NAME: &str = "ballista.job.name";
 pub const BALLISTA_DEFAULT_SHUFFLE_PARTITIONS: &str = "ballista.shuffle.partitions";
 pub const BALLISTA_DEFAULT_BATCH_SIZE: &str = "ballista.batch.size";
 pub const BALLISTA_REPARTITION_JOINS: &str = "ballista.repartition.joins";
@@ -156,7 +156,7 @@ impl BallistaConfig {
     /// All available configuration options
     pub fn valid_entries() -> HashMap<String, ConfigEntry> {
         let entries = vec![
-            ConfigEntry::new(BALLISTA_APP_NAME.to_string(),
+            ConfigEntry::new(BALLISTA_JOB_NAME.to_string(),
                              "Sets the job name that will appear in the web user interface for any submitted jobs".to_string(),
                              DataType::Utf8, None),
             ConfigEntry::new(BALLISTA_DEFAULT_SHUFFLE_PARTITIONS.to_string(),

--- a/ballista/rust/core/src/config.rs
+++ b/ballista/rust/core/src/config.rs
@@ -119,6 +119,8 @@ impl BallistaConfig {
                 Self::parse_value(v.as_str(), entry._data_type.clone()).map_err(|e| BallistaError::General(format!("Failed to parse user-supplied value '{}' for configuration setting '{}': {}", name, v, e)))?;
             } else if let Some(v) = entry.default_value.clone() {
                 Self::parse_value(v.as_str(), entry._data_type.clone()).map_err(|e| BallistaError::General(format!("Failed to parse default value '{}' for configuration setting '{}': {}", name, v, e)))?;
+            } else if entry.default_value.is_none() {
+                // optional config
             } else {
                 return Err(BallistaError::General(format!(
                     "No value specified for mandatory configuration setting '{}'",

--- a/ballista/rust/core/src/execution_plans/distributed_query.rs
+++ b/ballista/rust/core/src/execution_plans/distributed_query.rs
@@ -195,6 +195,11 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             )),
         };
 
+        println!(
+            "submitting query with configs: {:?}",
+            self.config.settings()
+        );
+
         let stream = futures::stream::once(
             execute_query(self.scheduler_url.clone(), self.session_id.clone(), query)
                 .map_err(|e| ArrowError::ExternalError(Box::new(e))),

--- a/ballista/rust/core/src/execution_plans/distributed_query.rs
+++ b/ballista/rust/core/src/execution_plans/distributed_query.rs
@@ -195,11 +195,6 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             )),
         };
 
-        println!(
-            "submitting query with configs: {:?}",
-            self.config.settings()
-        );
-
         let stream = futures::stream::once(
             execute_query(self.scheduler_url.clone(), self.session_id.clone(), query)
                 .map_err(|e| ArrowError::ExternalError(Box::new(e))),

--- a/ballista/rust/scheduler/src/api/handlers.rs
+++ b/ballista/rust/scheduler/src/api/handlers.rs
@@ -39,6 +39,7 @@ pub struct ExecutorMetaResponse {
 #[derive(Debug, serde::Serialize)]
 pub struct JobResponse {
     pub job_id: String,
+    pub job_name: String,
     pub job_status: String,
     pub num_stages: usize,
     pub completed_stages: usize,
@@ -124,6 +125,7 @@ pub(crate) async fn get_jobs<T: AsLogicalPlan, U: AsExecutionPlan>(
                 ((job.completed_stages as f32 / job.num_stages as f32) * 100_f32) as u8;
             JobResponse {
                 job_id: job.job_id.to_string(),
+                job_name: job.job_name.to_owned().unwrap_or_default(),
                 job_status,
                 num_stages: job.num_stages,
                 completed_stages: job.completed_stages,

--- a/ballista/rust/scheduler/src/flight_sql.rs
+++ b/ballista/rust/scheduler/src/flight_sql.rs
@@ -296,7 +296,7 @@ impl FlightSqlServiceImpl {
     ) -> Result<String, Status> {
         let job_id = self.server.state.task_manager.generate_job_id();
         self.server
-            .submit_job(&job_id, ctx, plan)
+            .submit_job(&job_id, None, ctx, plan)
             .await
             .map_err(|e| {
                 let msg =

--- a/ballista/rust/scheduler/src/scheduler_server/event.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/event.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 pub enum QueryStageSchedulerEvent {
     JobQueued {
         job_id: String,
+        job_name: Option<String>,
         session_ctx: Arc<SessionContext>,
         plan: Box<LogicalPlan>,
     },

--- a/ballista/rust/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/grpc.rs
@@ -424,8 +424,9 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             debug!("Received plan for execution: {:?}", plan);
 
             let job_id = self.state.task_manager.generate_job_id();
+            let job_name = config.settings().get("ballista.app.name");
 
-            self.submit_job(&job_id, session_ctx, &plan)
+            self.submit_job(&job_id, job_name.cloned(), session_ctx, &plan)
                 .await
                 .map_err(|e| {
                     let msg =

--- a/ballista/rust/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/grpc.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use ballista_core::config::{BallistaConfig, TaskSchedulingPolicy, BALLISTA_APP_NAME};
+use ballista_core::config::{BallistaConfig, TaskSchedulingPolicy, BALLISTA_JOB_NAME};
 use ballista_core::serde::protobuf::execute_query_params::{OptionalSessionId, Query};
 use std::convert::TryInto;
 
@@ -424,7 +424,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             debug!("Received plan for execution: {:?}", plan);
 
             let job_id = self.state.task_manager.generate_job_id();
-            let job_name = config.settings().get(BALLISTA_APP_NAME);
+            let job_name = config.settings().get(BALLISTA_JOB_NAME);
 
             self.submit_job(&job_id, job_name.cloned(), session_ctx, &plan)
                 .await

--- a/ballista/rust/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/grpc.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use ballista_core::config::{BallistaConfig, TaskSchedulingPolicy};
+use ballista_core::config::{BallistaConfig, TaskSchedulingPolicy, BALLISTA_APP_NAME};
 use ballista_core::serde::protobuf::execute_query_params::{OptionalSessionId, Query};
 use std::convert::TryInto;
 
@@ -424,7 +424,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             debug!("Received plan for execution: {:?}", plan);
 
             let job_id = self.state.task_manager.generate_job_id();
-            let job_name = config.settings().get("ballista.app.name");
+            let job_name = config.settings().get(BALLISTA_APP_NAME);
 
             self.submit_job(&job_id, job_name.cloned(), session_ctx, &plan)
                 .await

--- a/ballista/rust/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/mod.rs
@@ -141,6 +141,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
     pub(crate) async fn submit_job(
         &self,
         job_id: &str,
+        job_name: Option<String>,
         ctx: Arc<SessionContext>,
         plan: &LogicalPlan,
     ) -> Result<()> {
@@ -148,6 +149,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
             .get_sender()?
             .post_event(QueryStageSchedulerEvent::JobQueued {
                 job_id: job_id.to_owned(),
+                job_name,
                 session_ctx: ctx,
                 plan: Box::new(plan.clone()),
             })
@@ -337,7 +339,7 @@ mod test {
         // Submit job
         scheduler
             .state
-            .submit_job(job_id, ctx, &plan)
+            .submit_job(job_id, None, ctx, &plan)
             .await
             .expect("submitting plan");
 
@@ -442,7 +444,7 @@ mod test {
 
         let job_id = "job";
 
-        scheduler.state.submit_job(job_id, ctx, &plan).await?;
+        scheduler.state.submit_job(job_id, None, ctx, &plan).await?;
 
         // Complete tasks that are offered through scheduler events
         loop {
@@ -591,7 +593,7 @@ mod test {
 
         let job_id = "job";
 
-        scheduler.state.submit_job(job_id, ctx, &plan).await?;
+        scheduler.state.submit_job(job_id, None, ctx, &plan).await?;
 
         let available_tasks = scheduler
             .state
@@ -727,7 +729,7 @@ mod test {
         let job_id = "job";
 
         // This should fail when we try and create the physical plan
-        scheduler.submit_job(job_id, ctx, &plan).await?;
+        scheduler.submit_job(job_id, None, ctx, &plan).await?;
 
         let scheduler = scheduler.clone();
 

--- a/ballista/rust/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/rust/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -72,14 +72,16 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
         match event {
             QueryStageSchedulerEvent::JobQueued {
                 job_id,
+                job_name,
                 session_ctx,
                 plan,
             } => {
-                info!("Job {} queued", job_id);
+                info!("Job {} queued with name {:?}", job_id, job_name);
                 let state = self.state.clone();
                 tokio::spawn(async move {
-                    let event = if let Err(e) =
-                        state.submit_job(&job_id, session_ctx, &plan).await
+                    let event = if let Err(e) = state
+                        .submit_job(&job_id, job_name, session_ctx, &plan)
+                        .await
                     {
                         let msg = format!("Error planning job {}: {:?}", job_id, e);
                         error!("{}", &msg);

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -140,8 +140,6 @@ impl ExecutionGraph {
         session_id: &str,
         plan: Arc<dyn ExecutionPlan>,
     ) -> Result<Self> {
-        println!("ExecutionGraph::new() job_name={:?}", job_name);
-
         let mut planner = DistributedPlanner::new();
 
         let output_partitions = plan.output_partitioning().partition_count();
@@ -154,7 +152,7 @@ impl ExecutionGraph {
         Ok(Self {
             scheduler_id: scheduler_id.to_string(),
             job_id: job_id.to_string(),
-            job_name: job_name.map(|name| name.to_string()),
+            job_name,
             session_id: session_id.to_string(),
             status: JobStatus {
                 status: Some(job_status::Status::Queued(QueuedJob {})),

--- a/ballista/rust/scheduler/src/state/execution_graph.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph.rs
@@ -104,6 +104,8 @@ pub struct ExecutionGraph {
     scheduler_id: String,
     /// ID for this job
     job_id: String,
+    /// Optional job name
+    job_name: Option<String>,
     /// Session ID for this job
     session_id: String,
     /// Status of this job
@@ -134,9 +136,12 @@ impl ExecutionGraph {
     pub fn new(
         scheduler_id: &str,
         job_id: &str,
+        job_name: Option<String>,
         session_id: &str,
         plan: Arc<dyn ExecutionPlan>,
     ) -> Result<Self> {
+        println!("ExecutionGraph::new() job_name={:?}", job_name);
+
         let mut planner = DistributedPlanner::new();
 
         let output_partitions = plan.output_partitioning().partition_count();
@@ -149,6 +154,7 @@ impl ExecutionGraph {
         Ok(Self {
             scheduler_id: scheduler_id.to_string(),
             job_id: job_id.to_string(),
+            job_name: job_name.map(|name| name.to_string()),
             session_id: session_id.to_string(),
             status: JobStatus {
                 status: Some(job_status::Status::Queued(QueuedJob {})),
@@ -163,6 +169,10 @@ impl ExecutionGraph {
 
     pub fn job_id(&self) -> &str {
         self.job_id.as_str()
+    }
+
+    pub fn job_name(&self) -> Option<&String> {
+        self.job_name.as_ref()
     }
 
     pub fn session_id(&self) -> &str {
@@ -1276,6 +1286,11 @@ impl ExecutionGraph {
         Ok(ExecutionGraph {
             scheduler_id: proto.scheduler_id,
             job_id: proto.job_id,
+            job_name: if proto.job_name.is_empty() {
+                None
+            } else {
+                Some(proto.job_name)
+            },
             session_id: proto.session_id,
             status: proto.status.ok_or_else(|| {
                 BallistaError::Internal(
@@ -1351,6 +1366,7 @@ impl ExecutionGraph {
 
         Ok(protobuf::ExecutionGraph {
             job_id: graph.job_id,
+            job_name: graph.job_name.unwrap_or_default(),
             session_id: graph.session_id,
             status: Some(graph.status),
             stages,
@@ -2734,7 +2750,7 @@ mod test {
 
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
-        ExecutionGraph::new("localhost:50050", "job", "session", plan).unwrap()
+        ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap()
     }
 
     async fn test_two_aggregations_plan(partition: usize) -> ExecutionGraph {
@@ -2762,7 +2778,7 @@ mod test {
 
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
-        ExecutionGraph::new("localhost:50050", "job", "session", plan).unwrap()
+        ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap()
     }
 
     async fn test_coalesce_plan(partition: usize) -> ExecutionGraph {
@@ -2785,7 +2801,7 @@ mod test {
 
         let plan = ctx.create_physical_plan(&optimized_plan).await.unwrap();
 
-        ExecutionGraph::new("localhost:50050", "job", "session", plan).unwrap()
+        ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap()
     }
 
     async fn test_join_plan(partition: usize) -> ExecutionGraph {
@@ -2827,7 +2843,7 @@ mod test {
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
         let graph =
-            ExecutionGraph::new("localhost:50050", "job", "session", plan).unwrap();
+            ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap();
 
         println!("{:?}", graph);
 
@@ -2852,7 +2868,7 @@ mod test {
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
         let graph =
-            ExecutionGraph::new("localhost:50050", "job", "session", plan).unwrap();
+            ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap();
 
         println!("{:?}", graph);
 
@@ -2877,7 +2893,7 @@ mod test {
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
         let graph =
-            ExecutionGraph::new("localhost:50050", "job", "session", plan).unwrap();
+            ExecutionGraph::new("localhost:50050", "job", None, "session", plan).unwrap();
 
         println!("{:?}", graph);
 

--- a/ballista/rust/scheduler/src/state/execution_graph_dot.rs
+++ b/ballista/rust/scheduler/src/state/execution_graph_dot.rs
@@ -465,7 +465,8 @@ mod tests {
             .await?;
         let plan = df.to_logical_plan()?;
         let plan = ctx.create_physical_plan(&plan).await?;
-        let graph = ExecutionGraph::new("scheduler_id", "job_id", "session_id", plan)?;
+        let graph =
+            ExecutionGraph::new("scheduler_id", "job_id", None, "session_id", plan)?;
         let dot = ExecutionGraphDot::generate(Arc::new(graph))
             .map_err(|e| BallistaError::Internal(format!("{:?}", e)))?;
 

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -251,6 +251,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
     pub(crate) async fn submit_job(
         &self,
         job_id: &str,
+        job_name: Option<String>,
         session_ctx: Arc<SessionContext>,
         plan: &LogicalPlan,
     ) -> Result<()> {
@@ -262,7 +263,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         let plan = session_ctx.create_physical_plan(&optimized_plan).await?;
 
         self.task_manager
-            .submit_job(job_id, &session_ctx.session_id(), plan)
+            .submit_job(job_id, job_name, &session_ctx.session_id(), plan)
             .await?;
 
         let elapsed = start.elapsed();
@@ -357,19 +358,39 @@ mod test {
         // Create 4 jobs so we have four pending tasks
         state
             .task_manager
-            .submit_job("job-1", session_ctx.session_id().as_str(), plan.clone())
+            .submit_job(
+                "job-1",
+                None,
+                session_ctx.session_id().as_str(),
+                plan.clone(),
+            )
             .await?;
         state
             .task_manager
-            .submit_job("job-2", session_ctx.session_id().as_str(), plan.clone())
+            .submit_job(
+                "job-2",
+                None,
+                session_ctx.session_id().as_str(),
+                plan.clone(),
+            )
             .await?;
         state
             .task_manager
-            .submit_job("job-3", session_ctx.session_id().as_str(), plan.clone())
+            .submit_job(
+                "job-3",
+                None,
+                session_ctx.session_id().as_str(),
+                plan.clone(),
+            )
             .await?;
         state
             .task_manager
-            .submit_job("job-4", session_ctx.session_id().as_str(), plan.clone())
+            .submit_job(
+                "job-4",
+                None,
+                session_ctx.session_id().as_str(),
+                plan.clone(),
+            )
             .await?;
 
         let executors = test_executors(1, 4);
@@ -414,7 +435,12 @@ mod test {
         // Create a job
         state
             .task_manager
-            .submit_job("job-1", session_ctx.session_id().as_str(), plan.clone())
+            .submit_job(
+                "job-1",
+                None,
+                session_ctx.session_id().as_str(),
+                plan.clone(),
+            )
             .await?;
 
         let executors = test_executors(1, 4);

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -95,11 +95,12 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     pub async fn submit_job(
         &self,
         job_id: &str,
+        job_name: Option<String>,
         session_id: &str,
         plan: Arc<dyn ExecutionPlan>,
     ) -> Result<()> {
         let mut graph =
-            ExecutionGraph::new(&self.scheduler_id, job_id, session_id, plan)?;
+            ExecutionGraph::new(&self.scheduler_id, job_id, job_name, session_id, plan)?;
         info!("Submitting execution graph: {:?}", graph);
         self.state
             .put(
@@ -141,6 +142,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             }
             jobs.push(JobOverview {
                 job_id: job_id.clone(),
+                job_name: graph.job_name().cloned(),
                 status: graph.status(),
                 num_stages: graph.stage_count(),
                 completed_stages,
@@ -585,6 +587,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
 
 pub struct JobOverview {
     pub job_id: String,
+    pub job_name: Option<String>,
     pub status: JobStatus,
     pub num_stages: usize,
     pub completed_stages: usize,

--- a/ballista/ui/scheduler/src/components/QueriesList.tsx
+++ b/ballista/ui/scheduler/src/components/QueriesList.tsx
@@ -50,6 +50,7 @@ export enum QueryStatus {
 
 export interface Query {
   job_id: string;
+  job_name: string;
   status: QueryStatus;
   num_stages: number;
   percent_complete: number;
@@ -143,6 +144,10 @@ const columns: Column<any>[] = [
     Cell: LinkCell,
   },
   {
+    Header: "Job Name",
+    accessor: "job_name",
+  },
+  {
     Header: "Status",
     accessor: "job_status",
   },
@@ -163,8 +168,10 @@ const columns: Column<any>[] = [
   },
 ];
 
-const getSkeletion = () => (
+const getSkeleton = () => (
   <>
+    <Skeleton height={5} />
+    <Skeleton height={5} />
     <Skeleton height={5} />
     <Skeleton height={5} />
     <Skeleton height={5} />
@@ -189,7 +196,7 @@ export const QueriesList: React.FunctionComponent<QueriesListProps> = ({
             pb={10}
           />
         ) : (
-          getSkeletion()
+          getSkeleton()
         )}
       </Stack>
     </VStack>

--- a/docs/source/user-guide/configs.md
+++ b/docs/source/user-guide/configs.md
@@ -36,6 +36,7 @@ let ctx = BallistaContext::remote("localhost", 50050, &config).await?;
 
 | key                               | type    | default | description                                                                                                                                                               |
 | --------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ballista.app.name                 | Utf8    | N/A     | Sets the job name that will appear in the web user interface for any submitted jobs.                                                                                      |
 | ballista.shuffle.partitions       | UInt16  | 16      | Sets the default number of partitions to create when repartitioning query stages.                                                                                         |
 | ballista.batch.size               | UInt16  | 8192    | Sets the default batch size.                                                                                                                                              |
 | ballista.repartition.joins        | Boolean | true    | When set to true, Ballista will repartition data using the join keys to execute joins in parallel using the provided `ballista.shuffle.partitions` level.                 |

--- a/docs/source/user-guide/configs.md
+++ b/docs/source/user-guide/configs.md
@@ -35,7 +35,7 @@ let ctx = BallistaContext::remote("localhost", 50050, &config).await?;
 ## Ballista Configuration Settings
 
 | key                               | type    | default | description                                                                                                                                                               |
-|-----------------------------------| ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| --------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ballista.job.name                 | Utf8    | N/A     | Sets the job name that will appear in the web user interface for any submitted jobs.                                                                                      |
 | ballista.shuffle.partitions       | UInt16  | 16      | Sets the default number of partitions to create when repartitioning query stages.                                                                                         |
 | ballista.batch.size               | UInt16  | 8192    | Sets the default batch size.                                                                                                                                              |

--- a/docs/source/user-guide/configs.md
+++ b/docs/source/user-guide/configs.md
@@ -35,8 +35,8 @@ let ctx = BallistaContext::remote("localhost", 50050, &config).await?;
 ## Ballista Configuration Settings
 
 | key                               | type    | default | description                                                                                                                                                               |
-| --------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ballista.app.name                 | Utf8    | N/A     | Sets the job name that will appear in the web user interface for any submitted jobs.                                                                                      |
+|-----------------------------------| ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ballista.job.name                 | Utf8    | N/A     | Sets the job name that will appear in the web user interface for any submitted jobs.                                                                                      |
 | ballista.shuffle.partitions       | UInt16  | 16      | Sets the default number of partitions to create when repartitioning query stages.                                                                                         |
 | ballista.batch.size               | UInt16  | 8192    | Sets the default batch size.                                                                                                                                              |
 | ballista.repartition.joins        | Boolean | true    | When set to true, Ballista will repartition data using the join keys to execute joins in parallel using the provided `ballista.shuffle.partitions` level.                 |


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-ballista/issues/277

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Easier to find my jobs now:

![query-names](https://user-images.githubusercontent.com/934084/193478491-55942763-34a9-4f4a-8b54-05936d57b3bf.png)

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Users can set the `ballista.job.name` config in their context and that name appears in UI.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
