### PR TITLE
Atomic support for enhancement

### DIFF
--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -40,6 +40,7 @@ async-trait = "0.1.41"
 ballista-core = { path = "../core", version = "0.8.0" }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
+dashmap = "5.4.0"
 datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "06a4f79f02fcb6ea85303925b7c5a9b0231e3fee" }
 datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "06a4f79f02fcb6ea85303925b7c5a9b0231e3fee" }
 futures = "0.3"

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -45,6 +45,7 @@ ballista-core = { path = "../core", version = "0.8.0" }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
+dashmap = "5.4.0"
 datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "06a4f79f02fcb6ea85303925b7c5a9b0231e3fee" }
 datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "06a4f79f02fcb6ea85303925b7c5a9b0231e3fee" }
 etcd-client = { version = "0.9", optional = true }

--- a/ballista/rust/scheduler/src/state/backend/mod.rs
+++ b/ballista/rust/scheduler/src/state/backend/mod.rs
@@ -17,7 +17,7 @@
 
 use ballista_core::error::Result;
 use clap::ArgEnum;
-use futures::Stream;
+use futures::{future, Stream};
 use std::collections::HashSet;
 use std::fmt;
 use tokio::sync::OwnedMutexGuard;
@@ -60,6 +60,12 @@ pub enum Keyspace {
     Heartbeats,
 }
 
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub enum Operation {
+    Put(Vec<u8>),
+    Delete,
+}
+
 /// A trait that contains the necessary methods to save and retrieve the state and configuration of a cluster.
 #[tonic::async_trait]
 pub trait StateBackendClient: Send + Sync {
@@ -90,8 +96,20 @@ pub trait StateBackendClient: Send + Sync {
     /// Saves the value into the provided key, overriding any previous data that might have been associated to that key.
     async fn put(&self, keyspace: Keyspace, key: String, value: Vec<u8>) -> Result<()>;
 
-    /// Save multiple values in a single transaction. Either all values should be saved, or all should fail
-    async fn put_txn(&self, ops: Vec<(Keyspace, String, Vec<u8>)>) -> Result<()>;
+    /// Bundle multiple operation in a single transaction. Either all values should be saved, or all should fail.
+    /// It can support multiple types of operations and keyspaces. If the count of the unique keyspace is more than one,
+    /// more than one locks has to be acquired.
+    async fn apply_txn(&self, ops: Vec<(Operation, Keyspace, String)>) -> Result<()>;
+    /// Acquire mutex with specified IDs.
+    async fn acquire_locks(
+        &self,
+        mut ids: Vec<(Keyspace, &str)>,
+    ) -> Result<Vec<Box<dyn Lock>>> {
+        // We always acquire locks in a specific order to avoid deadlocks.
+        ids.sort_by_key(|n| format!("/{:?}/{}", n.0, n.1));
+        future::try_join_all(ids.into_iter().map(move |(ks, key)| self.lock(ks, key)))
+            .await
+    }
 
     /// Atomically move the given key from one keyspace to another
     async fn mv(

--- a/ballista/rust/scheduler/src/state/backend/mod.rs
+++ b/ballista/rust/scheduler/src/state/backend/mod.rs
@@ -107,8 +107,7 @@ pub trait StateBackendClient: Send + Sync {
     ) -> Result<Vec<Box<dyn Lock>>> {
         // We always acquire locks in a specific order to avoid deadlocks.
         ids.sort_by_key(|n| format!("/{:?}/{}", n.0, n.1));
-        future::try_join_all(ids.into_iter().map(move |(ks, key)| self.lock(ks, key)))
-            .await
+        future::try_join_all(ids.into_iter().map(|(ks, key)| self.lock(ks, key))).await
     }
 
     /// Atomically move the given key from one keyspace to another

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -274,11 +274,12 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
     }
 }
 
-pub async fn with_lock<Out, F: Future<Output = Out>>(lock: Box<dyn Lock>, op: F) -> Out {
-    let mut lock = lock;
+pub async fn with_lock<Out, F: Future<Output = Out>>(
+    mut lock: Box<dyn Lock>,
+    op: F,
+) -> Out {
     let result = op.await;
     lock.unlock().await;
-
     result
 }
 /// It takes multiple locks and reverse the order for releasing them to prevent a race condition.
@@ -286,10 +287,8 @@ pub async fn with_locks<Out, F: Future<Output = Out>>(
     locks: Vec<Box<dyn Lock>>,
     op: F,
 ) -> Out {
-    let mut locks = locks;
     let result = op.await;
-    locks.reverse();
-    for mut lock in locks {
+    for mut lock in locks.into_iter().rev() {
         lock.unlock().await;
     }
     result

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -281,6 +281,19 @@ pub async fn with_lock<Out, F: Future<Output = Out>>(lock: Box<dyn Lock>, op: F)
 
     result
 }
+/// It takes multiple locks and reverse the order for releasing them to prevent a race condition.
+pub async fn with_locks<Out, F: Future<Output = Out>>(
+    locks: Vec<Box<dyn Lock>>,
+    op: F,
+) -> Out {
+    let mut locks = locks;
+    let result = op.await;
+    locks.reverse();
+    for mut lock in locks {
+        lock.unlock().await;
+    }
+    result
+}
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
# Which issue does this PR close?

Closes [101](https://github.com/apache/arrow-ballista/issues/101) and address multiple TODOs inside the codebase.

 # Rationale for this change
If a large number of states undergo updates, using `RwLock` for the scheduler's in-memory states at the global level will reduce the overall performance. Additionally, some state updates are not atomic and were listed as TODOs. The modifications in this PR makes concurrency more efficient during heavily loaded in-memory updates and more reliable during state persistence.

# What changes are included in this PR?
- Changed `RwLock<HashMap<K, V>>` into a `DashMap`. The [dashmap](https://docs.rs/dashmap) crate provides an implementation of a more sophisticated, high-performance concurrent hash map. For reference, DashMap stats are

  | Stars      | Forks      | Used By | Contributors | License     |
  |------------|------------|---------|--------------|-------------|
  | 1.8k stars | 104  forks | 42.8k   | 34           | MIT license |

- Now performing atomic transactions on `TaskManager` and `ExecuterManager`, resolving `TODO`s.
  - Change in `trait StateBackendClient`, converted method `put_txn` to a more general `apply_txn`.
  - Rollback if the state persisting is not successful.

# Are there any user-facing changes?
No
