### PR TITLE
Show job stages metrics

### DIFF
--- a/ballista/ui/scheduler/src/components/JobStagesMetrics.tsx
+++ b/ballista/ui/scheduler/src/components/JobStagesMetrics.tsx
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import React, { useEffect, useState } from "react";
+import {
+  CircularProgress,
+  CircularProgressLabel,
+  VStack,
+  Skeleton,
+  Stack,
+  Text,
+  Flex,
+  Box,
+  useDisclosure,
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  propNames,
+} from "@chakra-ui/react";
+import { Column, DataTable } from "./DataTable";
+
+export enum StageStatus {
+  QUEUED = "QUEUED",
+  RUNNING = "RUNNING",
+  FAILED = "FAILED",
+  COMPLETED = "COMPLETED",
+}
+
+export interface Stage {
+  stage_id: string;
+  stage_status: StageStatus;
+  input_rows: number;
+  output_rows: number
+  elapsed_compute: string;
+}
+
+export interface StagesListProps {
+  stages?: Stage[];
+}
+
+const columns: Column<any>[] = [
+  {
+    Header: "Stage ID",
+    accessor: "stage_id",
+  },
+  {
+    Header: "Status",
+    accessor: "stage_status",
+  },
+  {
+    Header: "Input Rows",
+    accessor: "input_rows",
+  },
+  {
+    Header: "Output Rows",
+    accessor: "output_rows",
+  },
+  {
+    Header: "Computation time",
+    accessor: "elapsed_compute",
+    
+  },
+];
+
+const getSkeleton = () => (
+  <>
+    <Skeleton height={5} />
+    <Skeleton height={5} />
+    <Skeleton height={5} />
+    <Skeleton height={5} />
+    <Skeleton height={5} />
+  </>
+);
+
+export const JobStagesQueries: React.FunctionComponent<StagesListProps> = ({
+  stages,
+}) => {
+
+  
+  const isLoaded = typeof stages !== "undefined";
+
+  return (
+    <Box w={"100%"} flex={1}>
+      {isLoaded ? (
+        <DataTable
+          columns={columns}
+          data={stages || []}
+          pageSize={10}
+          pb={10}
+        />
+      ) : (
+        getSkeleton()
+      )}
+    </Box>
+  );
+};

--- a/ballista/ui/scheduler/src/components/JobStagesMetrics.tsx
+++ b/ballista/ui/scheduler/src/components/JobStagesMetrics.tsx
@@ -15,27 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import React, { useEffect, useState } from "react";
-import {
-  CircularProgress,
-  CircularProgressLabel,
-  VStack,
-  Skeleton,
-  Stack,
-  Text,
-  Flex,
-  Box,
-  useDisclosure,
-  Button,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  propNames,
-} from "@chakra-ui/react";
+import { Skeleton, Box } from "@chakra-ui/react";
 import { Column, DataTable } from "./DataTable";
 
 export enum StageStatus {
@@ -49,7 +29,7 @@ export interface Stage {
   stage_id: string;
   stage_status: StageStatus;
   input_rows: number;
-  output_rows: number
+  output_rows: number;
   elapsed_compute: string;
 }
 
@@ -77,7 +57,6 @@ const columns: Column<any>[] = [
   {
     Header: "Computation time",
     accessor: "elapsed_compute",
-    
   },
 ];
 
@@ -94,8 +73,6 @@ const getSkeleton = () => (
 export const JobStagesQueries: React.FunctionComponent<StagesListProps> = ({
   stages,
 }) => {
-
-  
   const isLoaded = typeof stages !== "undefined";
 
   return (

--- a/ballista/ui/scheduler/src/components/QueriesList.tsx
+++ b/ballista/ui/scheduler/src/components/QueriesList.tsx
@@ -16,7 +16,7 @@
 // under the License.
 
 import React, { useEffect, useState } from "react";
-import { ExternalLinkIcon } from '@chakra-ui/icons';
+import { ExternalLinkIcon } from "@chakra-ui/icons";
 import {
   CircularProgress,
   CircularProgressLabel,
@@ -113,7 +113,9 @@ export const ActionsCell: (props: any) => React.ReactNode = (props: any) => {
       <Modal isOpen={isOpen} size="small" onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader textAlign={"center"}>Graph for {props.value} job</ModalHeader>
+          <ModalHeader textAlign={"center"}>
+            Graph for {props.value} job
+          </ModalHeader>
           <ModalCloseButton />
           <ModalBody margin="auto">
             <SVG innerRef={ref} src={dot_data} width="auto" />
@@ -147,21 +149,23 @@ export const JobLinkCell: (props: any) => React.ReactNode = (props: any) => {
   };
 
   useEffect(() => {
-    if (isOpen && !loaded){ 
+    if (isOpen && !loaded) {
       getStages("/api/job/" + props.value + "/stages");
       setLoaded(true);
     }
-    
   }, [stages, isOpen]);
 
   return (
     <Flex>
-    <Link onClick={onOpen} icon>{props.value} <ExternalLinkIcon mx='2px' />
+      <Link onClick={onOpen} icon>
+        {props.value} <ExternalLinkIcon mx="2px" />
       </Link>
       <Modal isOpen={isOpen} size="small" onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader textAlign={"center"}>Stages metrics for {props.value} job</ModalHeader>
+          <ModalHeader textAlign={"center"}>
+            Stages metrics for {props.value} job
+          </ModalHeader>
           <ModalCloseButton />
           <ModalBody margin="auto">
             <JobStagesQueries stages={stages} />
@@ -173,7 +177,7 @@ export const JobLinkCell: (props: any) => React.ReactNode = (props: any) => {
           </ModalFooter>
         </ModalContent>
       </Modal>
-      </Flex>
+    </Flex>
   );
 };
 

--- a/ballista/ui/scheduler/src/components/QueriesList.tsx
+++ b/ballista/ui/scheduler/src/components/QueriesList.tsx
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ExternalLinkIcon } from '@chakra-ui/icons';
 import {
   CircularProgress,
@@ -113,7 +113,7 @@ export const ActionsCell: (props: any) => React.ReactNode = (props: any) => {
       <Modal isOpen={isOpen} size="small" onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Graph for {props.value} job</ModalHeader>
+          <ModalHeader textAlign={"center"}>Graph for {props.value} job</ModalHeader>
           <ModalCloseButton />
           <ModalBody margin="auto">
             <SVG innerRef={ref} src={dot_data} width="auto" />
@@ -129,14 +129,10 @@ export const ActionsCell: (props: any) => React.ReactNode = (props: any) => {
   );
 };
 
-
-
 export const JobLinkCell: (props: any) => React.ReactNode = (props: any) => {
   const [stages, setData] = useState();
   const [loaded, setLoaded] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const h1Ref = useRef<HTMLHeadingElement>(null);
-
 
   const getStages = (url: string) => {
     fetch(url, {
@@ -145,7 +141,7 @@ export const JobLinkCell: (props: any) => React.ReactNode = (props: any) => {
         Accept: "application/json",
       },
     }).then(async (res) => {
-      const jsonObj = JSON.parse(await res.text());
+      const jsonObj = await res.json();
       setData(jsonObj["stages"]);
     });
   };
@@ -154,13 +150,9 @@ export const JobLinkCell: (props: any) => React.ReactNode = (props: any) => {
     if (isOpen && !loaded){ 
       getStages("/api/job/" + props.value + "/stages");
       setLoaded(true);
-       
-    } else if (isOpen && loaded) {
-      console.log(stages);
-      
     }
     
-  }, [stages, h1Ref.current, isOpen]);
+  }, [stages, isOpen]);
 
   return (
     <Flex>
@@ -169,7 +161,7 @@ export const JobLinkCell: (props: any) => React.ReactNode = (props: any) => {
       <Modal isOpen={isOpen} size="small" onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader alignContent={"center"}>Stages metrics for {props.value} job</ModalHeader>
+          <ModalHeader textAlign={"center"}>Stages metrics for {props.value} job</ModalHeader>
           <ModalCloseButton />
           <ModalBody margin="auto">
             <JobStagesQueries stages={stages} />


### PR DESCRIPTION
# Which issue does this PR close?
Closes #306 .

 # Rationale for this change
As per #306

# What changes are included in this PR?
A new component for the stages metrics and the necessary glue code.

# Are there any user-facing changes?
Yes, the job id can now be clicked and a modal window appears. 

@andygrove -- the initial issue was mentioning that once a job id is clicked, a new window will open. I am new to React and after spending some hours trying to figure out how to use `react-router` without much success, I resorted to using the `modal` option. This allows us to keep the look & feel that we have with the graph view. Of course, happy to change to opening in a new window if that's what's better (which might be... depending on what UI features will be needed and how they will be implemented)

![image](https://user-images.githubusercontent.com/71919805/194222677-b3c74b3a-58df-4a9e-b013-901858324056.png)
