### PR TITLE
Add `cancel_job` REST API

### DIFF
--- a/ballista/rust/scheduler/src/api/mod.rs
+++ b/ballista/rust/scheduler/src/api/mod.rs
@@ -97,6 +97,11 @@ pub fn get_routes<T: AsLogicalPlan + Clone, U: 'static + AsExecutionPlan>(
         .and(with_data_server(scheduler_server.clone()))
         .and_then(|data_server| handlers::get_jobs(data_server));
 
+    let route_cancel_job = warp::path!("api" / "job" / String)
+        .and(warp::patch())
+        .and(with_data_server(scheduler_server.clone()))
+        .and_then(|job_id, data_server| handlers::cancel_job(data_server, job_id));
+
     let route_query_stages = warp::path!("api" / "job" / String / "stages")
         .and(with_data_server(scheduler_server.clone()))
         .and_then(|job_id, data_server| handlers::get_query_stages(data_server, job_id));
@@ -119,6 +124,7 @@ pub fn get_routes<T: AsLogicalPlan + Clone, U: 'static + AsExecutionPlan>(
     let routes = route_scheduler_state
         .or(route_executors)
         .or(route_jobs)
+        .or(route_cancel_job)
         .or(route_query_stages)
         .or(route_job_dot)
         .or(route_query_stage_dot)

--- a/docs/source/user-guide/scheduler.md
+++ b/docs/source/user-guide/scheduler.md
@@ -29,8 +29,9 @@ The scheduler provides a web user interface that allows queries to be monitored.
 
 The scheduler also provides a REST API that allows jobs to be monitored.
 
-| API                   | Description                                                 |
-| --------------------- | ----------------------------------------------------------- |
-| /api/jobs             | Get a list of jobs that have been submitted to the cluster. |
-| /api/job/{job_id}     | Get a summary of a submitted job.                           |
-| /api/job/{job_id}/dot | Produce a query plan in DOT (graphviz) format.              |
+| API                   | Method | Description                                                 |
+| --------------------- | ------ | ----------------------------------------------------------- |
+| /api/jobs             | GET    | Get a list of jobs that have been submitted to the cluster. |
+| /api/job/{job_id}     | GET    | Get a summary of a submitted job.                           |
+| /api/job/{job_id}/dot | GET    | Produce a query plan in DOT (graphviz) format.              |
+| /api/job/{job_id}     | PATCH  | Cancel a currently running job                              |


### PR DESCRIPTION
Hi all! Hope to get more involved with the project over the next few weeks. Thought id start with some easier items.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

part of #265

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Moved grpc cancellation logic to `SchedulerState` so that it could be reused by the REST interface. Kept error handling behavior the same, but added a 404 return when canceling a job that doesn't exist.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
For any long running tasks, users can execute a *PATCH* request on the job. for example: 


`curl -X PATCH -v -H 'Accept: application/json'  http://localhost:50050/api/job/25UPl4w | jq`

### _NOTE_
When testing out this addition, I found that cancelling the job causes a few errors:

1. The scheduler always fails its grpc call to the executor to `cancel_tasks()`, and returns with an `Unipmlemented` code. From looking at the executor logs, it doesn't seem to even reach them.

3. The scheduler goes into an infinite loop 
       
![image](https://user-images.githubusercontent.com/36749299/194974515-d858b9ac-b183-47d3-b0c0-3661e8b48011.png)

I think the bugs are unrelated. I'm happy to help debug, but I thought I'd post what I had since the changes are useful for debugging with `curl`




<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
