### PR TITLE
Using local shuffle reader avoid flight rpc call.

### DIFF
--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -70,6 +70,7 @@ tonic = "0.8"
 url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }
 walkdir = "2.3.2"
+sys-info = "0.9.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -64,13 +64,13 @@ prost-types = "0.11"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 sqlparser = "0.25"
+sys-info = "0.9.0"
 tokio = "1.0"
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.8"
 url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }
 walkdir = "2.3.2"
-sys-info = "0.9.0"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #346.

There is a situation when shuffler reader and writer are on the same machine. So we can read from directly from local disk without calling RPC and arrow-flight decoding.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
