### PR TITLE
Make the scheduler event loop buffer size configurable

### DIFF
--- a/ballista/scheduler/scheduler_config_spec.toml
+++ b/ballista/scheduler/scheduler_config_spec.toml
@@ -73,6 +73,12 @@ doc = "The scheduing policy for the scheduler, possible values: pull-staged, pus
 default = "ballista_core::config::TaskSchedulingPolicy::PullStaged"
 
 [[param]]
+name = "event_loop_buffer_size"
+type = "u32"
+default = "10000"
+doc = "Event loop buffer size. Default: 10000"
+
+[[param]]
 name = "executor_slots_policy"
 type = "ballista_scheduler::config::SlotsPolicy"
 doc = "The executor slots policy for the scheduler, possible values: bias, round-robin, round-robin-local. Default: bias"

--- a/ballista/scheduler/src/main.rs
+++ b/ballista/scheduler/src/main.rs
@@ -74,6 +74,7 @@ async fn start_server(
     addr: SocketAddr,
     scheduling_policy: TaskSchedulingPolicy,
     slots_policy: SlotsPolicy,
+    event_loop_buffer_size: usize,
 ) -> Result<()> {
     info!(
         "Ballista v{} Scheduler listening on {:?}",
@@ -93,11 +94,13 @@ async fn start_server(
                 slots_policy,
                 BallistaCodec::default(),
                 default_session_builder,
+                event_loop_buffer_size,
             ),
             _ => SchedulerServer::new(
                 scheduler_name,
                 config_backend.clone(),
                 BallistaCodec::default(),
+                event_loop_buffer_size,
             ),
         };
 
@@ -244,12 +247,14 @@ async fn main() -> Result<()> {
 
     let scheduling_policy: TaskSchedulingPolicy = opt.scheduler_policy;
     let slots_policy: SlotsPolicy = opt.executor_slots_policy;
+    let event_loop_buffer_size = opt.event_loop_buffer_size as usize;
     start_server(
         scheduler_name,
         client,
         addr,
         scheduling_policy,
         slots_policy,
+        event_loop_buffer_size,
     )
     .await?;
     Ok(())

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -582,6 +582,7 @@ mod test {
                 "localhost:50050".to_owned(),
                 state_storage.clone(),
                 BallistaCodec::default(),
+                10000,
             );
         scheduler.init().await?;
         let exec_meta = ExecutorRegistration {
@@ -667,6 +668,7 @@ mod test {
                 "localhost:50050".to_owned(),
                 state_storage.clone(),
                 BallistaCodec::default(),
+                10000,
             );
         scheduler.init().await?;
 
@@ -746,6 +748,7 @@ mod test {
                 "localhost:50050".to_owned(),
                 state_storage.clone(),
                 BallistaCodec::default(),
+                10000,
             );
         scheduler.init().await?;
 

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -38,6 +38,7 @@ pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
             "localhost:50050".to_owned(),
             Arc::new(client),
             BallistaCodec::default(),
+            100000,
         );
     scheduler_server.init().await?;
     let server = SchedulerGrpcServer::new(scheduler_server.clone());

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -38,7 +38,7 @@ pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
             "localhost:50050".to_owned(),
             Arc::new(client),
             BallistaCodec::default(),
-            100000,
+            10000,
         );
     scheduler_server.init().await?;
     let server = SchedulerGrpcServer::new(scheduler_server.clone());


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #397.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Since the channel in the event loop is a bounded one, sometimes when there're many events produced in a short time, it will block the caller when sending events to the channel. If the buffer size is not larger enough, it will downgrade the performance, especially in a high throughput system.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
