### PR TITLE
scheduler now verifies that `file://` ListingTable URLs are accessible

### DIFF
--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -229,6 +229,7 @@ pub fn remove_unresolved_shuffles(
                     .iter()
                     .map(|c| c
                         .iter()
+                        .filter(|l| !l.path.is_empty())
                         .map(|l| l.path.clone())
                         .collect::<Vec<_>>()
                         .join(", "))

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -38,7 +38,7 @@ use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::file_format::FileFormat;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use futures::TryStreamExt;
-use log::{debug, error, info, warn};
+use log::{debug, error, info, trace, warn};
 
 use std::ops::Deref;
 use std::sync::Arc;
@@ -71,7 +71,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             task_status,
         } = request.into_inner()
         {
-            debug!("Received poll_work request for {:?}", metadata);
+            trace!("Received poll_work request for {:?}", metadata);
             // We might receive buggy poll work requests from dead executors.
             if self
                 .state

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -279,7 +279,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
                     if let Some(table) = provider.as_any().downcast_ref::<ListingTable>()
                     {
                         for url in table.table_paths() {
-                            // remove file:// prefix and verify that the file is accessible
+                            // remove file:/// prefix and verify that the file is accessible
                             let url = url.as_str();
                             let url = url.strip_prefix("file:///").unwrap_or(url);
                             ListingTableUrl::parse(url)

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -287,11 +287,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
                             for url in table.table_paths() {
                                 // remove file:// prefix and verify that the file is accessible
                                 let url = url.as_str();
-                                let url = if url.starts_with("file://") {
-                                    &url[7..]
-                                } else {
-                                    url
-                                };
+                                let url = url.strip_prefix("file://").unwrap_or(url);
                                 ListingTableUrl::parse(url)
                                     .map_err(|e| BallistaError::General(
                                         format!("logical plan refers to path that is not accessible in scheduler file system: {}: {:?}", url, e)))?;

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -281,7 +281,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
                         for url in table.table_paths() {
                             // remove file:// prefix and verify that the file is accessible
                             let url = url.as_str();
-                            let url = url.strip_prefix("file://").unwrap_or(url);
+                            let url = url.strip_prefix("file:///").unwrap_or(url);
                             ListingTableUrl::parse(url)
                                 .map_err(|e| BallistaError::General(
                                     format!("logical plan refers to path that is not accessible in scheduler file system: {}: {:?}", url, e)))?;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - "80:80"
       - "50050:50050"
     environment:
-      - RUST_LOG=info
+      - RUST_LOG=ballista=debug,info
     volumes:
       - ./benchmarks/data:/data
     depends_on:


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-ballista/issues/353

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

My query now fails rather than silently producing the wrong results (empty result set).

```
Error planning job JfrneIG: 
General(\"logical plan refers to path that is not accessible in scheduler file system: /mnt/bigdata/tpcds/sf100-parquet/store_returns.parquet/: IoError(Os { code: 2, kind: NotFound, message: \\\"No such file or directory\\\" })\")"))))
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Scheduler verifies files exist
- Logging changes

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
