### PR TITLE
Reorder joins after resolving stage inputs

### DIFF
--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -244,7 +244,6 @@ pub fn remove_unresolved_shuffles(
             new_children.push(remove_unresolved_shuffles(child, partition_locations)?);
         }
     }
-
     Ok(with_new_children_if_necessary(stage, new_children)?)
 }
 

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -244,6 +244,7 @@ pub fn remove_unresolved_shuffles(
             new_children.push(remove_unresolved_shuffles(child, partition_locations)?);
         }
     }
+
     Ok(with_new_children_if_necessary(stage, new_children)?)
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #387

On my dataset (SF=1, 16 partitions):

| Q | Old | New |
|---|-----|-----|
| 1 | 2606.73   | 2464.34  |
| 2 | 6979.12   | 6269.01  |
| 3 |  2973.81  | 2669.01  |
| 4 | 2051.11   | 2153.49   |
| 5 | 5046.95| 4859.44  |
| 6 | 825.36 | 759.49   |
| 7 | 10924.42 | 8643.63  |
| 8 | 5155.24| 4454.23  |
| 9 | 6623.82 | 6692.33   |
| 10 | 3591.48  | 3589.20   |
| 11 | 2794.17 | 2572.79   |
| 12 | 2046.36 | 2159.84   |
| 13 | 4303.23 | 4306.72   |
| 14 | 1338.51 | 1438.58   |
| 17 | 13895.35 | 11545.25  |
| 18 | 13177.04 | 14494.28  |
| 19 | 2459.90  | 1955.42   |
| 20 | 4095.79  | 4093.03   |
| 21 | 10783.26 | 9012.73   |

Differences are not too big (and results are noisy), but get some consistent improvements on q7, q8, q17, q19, q21

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
