### PR TITLE
Add optional flag which advertises host for Arrow Flight SQL #418

### DIFF
--- a/ballista/scheduler/scheduler_config_spec.toml
+++ b/ballista/scheduler/scheduler_config_spec.toml
@@ -25,6 +25,11 @@ name = "version"
 doc = "Print version of this executable"
 
 [[param]]
+name = "advertise_endpoint"
+type = "String"
+doc = "Route for proxying flight results via scheduler. Should be of the form 'IP:PORT'"
+
+[[param]]
 abbr = "b"
 name = "config_backend"
 type = "ballista_scheduler::state::backend::StateBackend"

--- a/ballista/scheduler/src/main.rs
+++ b/ballista/scheduler/src/main.rs
@@ -45,7 +45,7 @@ use ballista_scheduler::state::backend::{StateBackend, StateBackendClient};
 
 use ballista_core::config::TaskSchedulingPolicy;
 use ballista_core::serde::BallistaCodec;
-use ballista_core::utils::default_session_builder;
+
 use log::info;
 
 #[macro_use]
@@ -75,6 +75,7 @@ async fn start_server(
     scheduling_policy: TaskSchedulingPolicy,
     slots_policy: SlotsPolicy,
     event_loop_buffer_size: usize,
+    advertise_endpoint: Option<String>,
 ) -> Result<()> {
     info!(
         "Ballista v{} Scheduler listening on {:?}",
@@ -85,6 +86,7 @@ async fn start_server(
         "Starting Scheduler grpc server with task scheduling policy of {:?}",
         scheduling_policy
     );
+
     let mut scheduler_server: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =
         match scheduling_policy {
             TaskSchedulingPolicy::PushStaged => SchedulerServer::new_with_policy(
@@ -93,14 +95,15 @@ async fn start_server(
                 scheduling_policy,
                 slots_policy,
                 BallistaCodec::default(),
-                default_session_builder,
                 event_loop_buffer_size,
+                advertise_endpoint,
             ),
             _ => SchedulerServer::new(
                 scheduler_name,
                 config_backend.clone(),
                 BallistaCodec::default(),
                 event_loop_buffer_size,
+                advertise_endpoint,
             ),
         };
 
@@ -255,6 +258,7 @@ async fn main() -> Result<()> {
         scheduling_policy,
         slots_policy,
         event_loop_buffer_size,
+        opt.advertise_endpoint,
     )
     .await?;
     Ok(())

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -577,6 +577,7 @@ mod test {
                 state_storage.clone(),
                 BallistaCodec::default(),
                 10000,
+                None,
             );
         scheduler.init().await?;
         let exec_meta = ExecutorRegistration {
@@ -663,6 +664,7 @@ mod test {
                 state_storage.clone(),
                 BallistaCodec::default(),
                 10000,
+                None,
             );
         scheduler.init().await?;
 
@@ -743,6 +745,7 @@ mod test {
                 state_storage.clone(),
                 BallistaCodec::default(),
                 10000,
+                None,
             );
         scheduler.init().await?;
 

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -39,6 +39,7 @@ pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
             Arc::new(client),
             BallistaCodec::default(),
             10000,
+            None,
         );
     scheduler_server.init().await?;
     let server = SchedulerGrpcServer::new(scheduler_server.clone());


### PR DESCRIPTION
- Update scheduler_config_spec.toml to include new flag 'advertise_host'
- Add advertise_host member variable to SchedulerServer
- Add advertise_host argument to new, new_with_policy, new_with_builder, and new_with_state in order to propagate flag
- Add None argument to relevant method calls

Add optional flag which advertises host for Arrow Flight SQL #418

- Update logic in job_to_fetch_part to use advertise-host flag when it exists
- Remove default from advertise_host in scheduler_config_spec.toml
- Wrap scheduler_server advertise_host variable in Option
- Update scheduler's main.rs to reflect advertise_host being wrapped in Option

Utilize executor IP for routing to flight results in job_to_fetch_part even when advertise-host flag is set.

Add missing variable and ownership stuff

Remove unnecessary output from do_get_fallback

# Which issue does this PR close?

Closes #418

 # Rationale for this change

# What changes are included in this PR?

Adds member variable to SchedulerServer, adds argument to relevant constructors as necessary.

# Are there any user-facing changes?

Adds advertise-host flag for proxying via scheduler as described in original issue.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
