### PR TITLE
Don't throw error when job shuffle data path not exist in executor

### DIFF
--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -720,7 +720,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorGrpc
         request: Request<RemoveJobDataParams>,
     ) -> Result<Response<RemoveJobDataResult>, Status> {
         let job_id = request.into_inner().job_id;
-        info!("Remove data for job {:?}", job_id);
 
         let work_dir = PathBuf::from(&self.executor.work_dir);
         let mut path = work_dir.clone();
@@ -729,10 +728,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorGrpc
         // Verify it's an existing directory
         if !path.is_dir() {
             return if !path.exists() {
-                Err(Status::invalid_argument(format!(
-                    "Path {:?} does not exist!!!",
-                    path
-                )))
+                Ok(Response::new(RemoveJobDataResult {}))
             } else {
                 Err(Status::invalid_argument(format!(
                     "Path {:?} is not for a directory!!!",
@@ -747,6 +743,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorGrpc
                 path, work_dir
             )));
         }
+
+        info!("Remove data for job {:?}", job_id);
 
         std::fs::remove_dir_all(&path)?;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #502.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
