### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -440,6 +440,7 @@ message ExecutionGraph {
   string job_name = 10;
   uint64 start_time = 11;
   uint64 end_time = 12;
+  uint64 queued_at = 13;
 }
 
 message StageAttempts {

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -30,10 +30,11 @@ edition = "2018"
 scheduler = "scheduler_config_spec.toml"
 
 [features]
-default = ["etcd", "sled"]
+default = ["etcd", "sled", "prometheus"]
 etcd = ["etcd-client"]
 flight-sql = []
 sled = ["sled_package", "tokio-stream"]
+prometheus-metrics = ["prometheus"]
 
 
 [dependencies]
@@ -60,6 +61,7 @@ log = "0.4"
 object_store = "0.5.0"
 parking_lot = "0.12"
 parse_arg = "0.1.3"
+prometheus = { version = "0.13", features = ["process"], optional = true }
 prost = "0.11"
 prost-types = { version = "0.11.0" }
 rand = "0.8"

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -33,8 +33,8 @@ scheduler = "scheduler_config_spec.toml"
 default = ["etcd", "sled", "prometheus"]
 etcd = ["etcd-client"]
 flight-sql = []
-sled = ["sled_package", "tokio-stream"]
 prometheus-metrics = ["prometheus"]
+sled = ["sled_package", "tokio-stream"]
 
 
 [dependencies]

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -30,10 +30,10 @@ edition = "2018"
 scheduler = "scheduler_config_spec.toml"
 
 [features]
-default = ["etcd", "sled", "prometheus"]
+default = ["etcd", "sled", "prometheus-metrics"]
 etcd = ["etcd-client"]
 flight-sql = []
-prometheus-metrics = ["prometheus"]
+prometheus-metrics = ["prometheus", "once_cell"]
 sled = ["sled_package", "tokio-stream"]
 
 
@@ -59,6 +59,7 @@ hyper = "0.14.4"
 itertools = "0.10.3"
 log = "0.4"
 object_store = "0.5.0"
+once_cell = { version = "1.16.0", optional = true }
 parking_lot = "0.12"
 parse_arg = "0.1.3"
 prometheus = { version = "0.13", features = ["process"], optional = true }

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -347,3 +347,17 @@ pub(crate) async fn get_job_svg_graph<T: AsLogicalPlan, U: AsExecutionPlan>(
         _ => Ok("Not Found".to_string()),
     }
 }
+
+#[cfg(feature = "prometheus")]
+pub(crate) async fn get_scheduler_metrics<T: AsLogicalPlan, U: AsExecutionPlan>(
+    _data_server: SchedulerServer<T, U>,
+) -> Result<impl warp::Reply, Rejection> {
+    crate::metrics::prometheus::get_metrics().map_err(|_| warp::reject())
+}
+
+#[cfg(not(feature = "prometheus"))]
+pub(crate) async fn get_scheduler_metrics<T: AsLogicalPlan, U: AsExecutionPlan>(
+    _data_server: SchedulerServer<T, U>,
+) -> Result<impl warp::Reply, Rejection> {
+    Err(warp::reject())
+}

--- a/ballista/scheduler/src/api/mod.rs
+++ b/ballista/scheduler/src/api/mod.rs
@@ -118,8 +118,12 @@ pub fn get_routes<T: AsLogicalPlan + Clone, U: 'static + AsExecutionPlan>(
             });
 
     let route_job_dot_svg = warp::path!("api" / "job" / String / "dot_svg")
-        .and(with_data_server(scheduler_server))
+        .and(with_data_server(scheduler_server.clone()))
         .and_then(|job_id, data_server| handlers::get_job_svg_graph(data_server, job_id));
+
+    let route_scheduler_metrics = warp::path!("api" / "metrics")
+        .and(with_data_server(scheduler_server))
+        .and_then(|data_server| handlers::get_scheduler_metrics(data_server));
 
     let routes = route_scheduler_state
         .or(route_executors)
@@ -128,6 +132,7 @@ pub fn get_routes<T: AsLogicalPlan + Clone, U: 'static + AsExecutionPlan>(
         .or(route_query_stages)
         .or(route_job_dot)
         .or(route_query_stage_dot)
-        .or(route_job_dot_svg);
+        .or(route_job_dot_svg)
+        .or(route_scheduler_metrics);
     routes.boxed()
 }

--- a/ballista/scheduler/src/lib.rs
+++ b/ballista/scheduler/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod api;
 pub mod config;
 pub mod display;
+pub mod metrics;
 pub mod planner;
 pub mod scheduler_server;
 #[cfg(feature = "sled")]

--- a/ballista/scheduler/src/main.rs
+++ b/ballista/scheduler/src/main.rs
@@ -127,14 +127,14 @@ async fn start_server(
                     parts.extensions.insert(connect_info.clone());
                     let req = http::Request::from_parts(parts, body);
 
-                    let header = req.headers().get(hyper::header::ACCEPT);
-                    if header.is_some() && header.unwrap().eq("application/json") {
+                    if req.uri().path().starts_with("/api") {
                         return Either::Left(
                             warp.call(req)
                                 .map_ok(|res| res.map(EitherBody::Left))
                                 .map_err(Error::from),
                         );
                     }
+
                     Either::Right(
                         tonic
                             .call(req)

--- a/ballista/scheduler/src/main.rs
+++ b/ballista/scheduler/src/main.rs
@@ -66,6 +66,7 @@ use ballista_core::config::LogRotationPolicy;
 use ballista_scheduler::config::SchedulerConfig;
 #[cfg(feature = "flight-sql")]
 use ballista_scheduler::flight_sql::FlightSqlServiceImpl;
+use ballista_scheduler::metrics::default_metrics_collector;
 use config::prelude::*;
 use tracing_subscriber::EnvFilter;
 
@@ -85,12 +86,15 @@ async fn start_server(
         config.scheduling_policy
     );
 
+    let metrics_collector = default_metrics_collector()?;
+
     let mut scheduler_server: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =
         SchedulerServer::new(
             scheduler_name,
             config_backend.clone(),
             BallistaCodec::default(),
             config,
+            metrics_collector,
         );
 
     scheduler_server.init().await?;

--- a/ballista/scheduler/src/metrics/mod.rs
+++ b/ballista/scheduler/src/metrics/mod.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #[cfg(feature = "prometheus")]
 pub mod prometheus;
 

--- a/ballista/scheduler/src/metrics/mod.rs
+++ b/ballista/scheduler/src/metrics/mod.rs
@@ -43,9 +43,7 @@ impl SchedulerMetricsCollector for NoopMetricsCollector {
 
 #[cfg(feature = "prometheus")]
 pub fn default_metrics_collector() -> Result<Arc<dyn SchedulerMetricsCollector>> {
-    Ok(Arc::new(PrometheusMetricsCollector::new(
-        ::prometheus::default_registry(),
-    )?))
+    PrometheusMetricsCollector::current()
 }
 
 #[cfg(not(feature = "prometheus"))]

--- a/ballista/scheduler/src/metrics/mod.rs
+++ b/ballista/scheduler/src/metrics/mod.rs
@@ -22,14 +22,42 @@ use crate::metrics::prometheus::PrometheusMetricsCollector;
 use ballista_core::error::Result;
 use std::sync::Arc;
 
+/// Interface for recording metrics events in the scheduler. An instance of `Arc<dyn SchedulerMetricsCollector>`
+/// will be passed when constructing the `QueryStageScheduler` which is the core event loop of the scheduler.
+/// The event loop will then record metric events through this trait.
 pub trait SchedulerMetricsCollector: Send + Sync {
+    /// Record that job with `job_id` was submitted. This will be invoked
+    /// after the job's `ExecutionGraph` is created and it is ready to be scheduled
+    /// on executors.
+    /// When invoked should specify the timestamp in milliseconds when the job was originally
+    /// queued and the timestamp in milliseconds when it was submitted
     fn record_submitted(&self, job_id: &str, queued_at: u64, submitted_at: u64);
+
+    /// Record that job with `job_id` has completed successfully. This should only
+    /// be invoked on successful job completion.
+    /// When invoked should specify the timestamp in milliseconds when the job was originally
+    /// queued and the timestamp in milliseconds when it was completed
     fn record_completed(&self, job_id: &str, queued_at: u64, completed_at: u64);
+
+    /// Record that job with `job_id` has failed.
+    /// When invoked should specify the timestamp in milliseconds when the job was originally
+    /// queued and the timestamp in milliseconds when it failed.
     fn record_failed(&self, job_id: &str, queued_at: u64, failed_at: u64);
+
+    /// Record that job with `job_id` was cancelled.
     fn record_cancelled(&self, job_id: &str);
+
+    /// Set the current number of pending tasks in scheduler. A pending task is a task that is available
+    /// to schedule on an executor but cannot be scheduled because no resources are available.
     fn set_pending_tasks_queue_size(&self, value: u64);
+
+    /// Gather current metric set that should be returned when calling the scheduler's metrics API
+    /// Should return a tuple containing the content of the metric set and the content type (e.g. `application/json`, `text/plain`, etc)
+    fn gather_metrics(&self) -> Result<Option<(Vec<u8>, String)>>;
 }
 
+/// Implementation of `SchedulerMetricsCollector` that ignores all events. This can be used as
+/// a default implementation when tracking scheduler metrics is not required (or performed through other means)
 #[derive(Default)]
 pub struct NoopMetricsCollector {}
 
@@ -39,8 +67,13 @@ impl SchedulerMetricsCollector for NoopMetricsCollector {
     fn record_failed(&self, _job_id: &str, _queued_at: u64, _failed_at: u64) {}
     fn record_cancelled(&self, _job_id: &str) {}
     fn set_pending_tasks_queue_size(&self, _value: u64) {}
+
+    fn gather_metrics(&self) -> Result<Option<(Vec<u8>, String)>> {
+        Ok(None)
+    }
 }
 
+/// Return a reference to the systems default metrics collector.
 #[cfg(feature = "prometheus")]
 pub fn default_metrics_collector() -> Result<Arc<dyn SchedulerMetricsCollector>> {
     PrometheusMetricsCollector::current()

--- a/ballista/scheduler/src/metrics/mod.rs
+++ b/ballista/scheduler/src/metrics/mod.rs
@@ -1,0 +1,37 @@
+#[cfg(feature = "prometheus")]
+pub mod prometheus;
+
+use crate::metrics::prometheus::PrometheusMetricsCollector;
+use ballista_core::error::Result;
+use std::sync::Arc;
+
+pub trait SchedulerMetricsCollector: Send + Sync {
+    fn record_submitted(&self, job_id: &str, queued_at: u64, submitted_at: u64);
+    fn record_completed(&self, job_id: &str, queued_at: u64, completed_at: u64);
+    fn record_failed(&self, job_id: &str, queued_at: u64, failed_at: u64);
+    fn record_cancelled(&self, job_id: &str);
+    fn set_pending_tasks_queue_size(&self, value: u64);
+}
+
+#[derive(Default)]
+pub struct NoopMetricsCollector {}
+
+impl SchedulerMetricsCollector for NoopMetricsCollector {
+    fn record_submitted(&self, _job_id: &str, _queued_at: u64, _submitted_at: u64) {}
+    fn record_completed(&self, _job_id: &str, _queued_at: u64, _completed_att: u64) {}
+    fn record_failed(&self, _job_id: &str, _queued_at: u64, _failed_at: u64) {}
+    fn record_cancelled(&self, _job_id: &str) {}
+    fn set_pending_tasks_queue_size(&self, _value: u64) {}
+}
+
+#[cfg(feature = "prometheus")]
+pub fn default_metrics_collector() -> Result<Arc<dyn SchedulerMetricsCollector>> {
+    Ok(Arc::new(PrometheusMetricsCollector::new(
+        &::prometheus::default_registry(),
+    )?))
+}
+
+#[cfg(not(feature = "prometheus"))]
+pub fn default_metrics_collector() -> Result<Arc<dyn SchedulerMetricsCollector>> {
+    Ok(Arc::new(NoopMetricsCollector::default()))
+}

--- a/ballista/scheduler/src/metrics/mod.rs
+++ b/ballista/scheduler/src/metrics/mod.rs
@@ -27,7 +27,7 @@ impl SchedulerMetricsCollector for NoopMetricsCollector {
 #[cfg(feature = "prometheus")]
 pub fn default_metrics_collector() -> Result<Arc<dyn SchedulerMetricsCollector>> {
     Ok(Arc::new(PrometheusMetricsCollector::new(
-        &::prometheus::default_registry(),
+        ::prometheus::default_registry(),
     )?))
 }
 

--- a/ballista/scheduler/src/metrics/prometheus.rs
+++ b/ballista/scheduler/src/metrics/prometheus.rs
@@ -2,11 +2,11 @@ use crate::metrics::SchedulerMetricsCollector;
 use ballista_core::error::{BallistaError, Result};
 use hyper::header::CONTENT_TYPE;
 use prometheus::{
-    default_registry, register_counter_with_registry, register_gauge_with_registry,
+    register_counter_with_registry, register_gauge_with_registry,
     register_histogram_with_registry, Counter, Gauge, Histogram, Registry,
 };
 use prometheus::{Encoder, TextEncoder};
-use warp::reply::WithHeader;
+
 use warp::Reply;
 
 pub struct PrometheusMetricsCollector {

--- a/ballista/scheduler/src/metrics/prometheus.rs
+++ b/ballista/scheduler/src/metrics/prometheus.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use crate::metrics::SchedulerMetricsCollector;
 use ballista_core::error::{BallistaError, Result};
 use hyper::header::CONTENT_TYPE;

--- a/ballista/scheduler/src/metrics/prometheus.rs
+++ b/ballista/scheduler/src/metrics/prometheus.rs
@@ -1,0 +1,141 @@
+use crate::metrics::SchedulerMetricsCollector;
+use ballista_core::error::{BallistaError, Result};
+use hyper::header::CONTENT_TYPE;
+use prometheus::{
+    default_registry, register_counter_with_registry, register_gauge_with_registry,
+    register_histogram_with_registry, Counter, Gauge, Histogram, Registry,
+};
+use prometheus::{Encoder, TextEncoder};
+use warp::reply::WithHeader;
+use warp::Reply;
+
+pub struct PrometheusMetricsCollector {
+    execution_time: Histogram,
+    planning_time: Histogram,
+    failed: Counter,
+    cancelled: Counter,
+    completed: Counter,
+    submitted: Counter,
+    pending_queue_size: Gauge,
+}
+
+impl PrometheusMetricsCollector {
+    pub fn new(registry: &Registry) -> Result<Self> {
+        let execution_time = register_histogram_with_registry!(
+            "query_time_seconds",
+            "Histogram of query execution time in seconds",
+            vec![0.5_f64, 1_f64, 5_f64, 30_f64, 60_f64],
+            registry
+        )
+        .map_err(|e| {
+            BallistaError::Internal(format!("Error registering metric: {:?}", e))
+        })?;
+
+        let planning_time = register_histogram_with_registry!(
+            "planning_time_ms",
+            "Histogram of query planning time in milliseconds",
+            vec![1.0_f64, 5.0_f64, 25.0_f64, 100.0_f64, 500.0_f64],
+            registry
+        )
+        .map_err(|e| {
+            BallistaError::Internal(format!("Error registering metric: {:?}", e))
+        })?;
+
+        let failed = register_counter_with_registry!(
+            "query_failed_total",
+            "Counter of failed queries",
+            registry
+        )
+        .map_err(|e| {
+            BallistaError::Internal(format!("Error registering metric: {:?}", e))
+        })?;
+
+        let cancelled = register_counter_with_registry!(
+            "query_cancelled_total",
+            "Counter of cancelled queries",
+            registry
+        )
+        .map_err(|e| {
+            BallistaError::Internal(format!("Error registering metric: {:?}", e))
+        })?;
+
+        let completed = register_counter_with_registry!(
+            "query_completed_total",
+            "Counter of completed queries",
+            registry
+        )
+        .map_err(|e| {
+            BallistaError::Internal(format!("Error registering metric: {:?}", e))
+        })?;
+
+        let submitted = register_counter_with_registry!(
+            "query_submitted_total",
+            "Counter of submitted queries",
+            registry
+        )
+        .map_err(|e| {
+            BallistaError::Internal(format!("Error registering metric: {:?}", e))
+        })?;
+
+        let pending_queue_size = register_gauge_with_registry!(
+            "pending_queue_size",
+            "Number of pending tasks",
+            registry
+        )
+        .map_err(|e| {
+            BallistaError::Internal(format!("Error registering metric: {:?}", e))
+        })?;
+
+        Ok(Self {
+            execution_time,
+            planning_time,
+            failed,
+            cancelled,
+            completed,
+            submitted,
+            pending_queue_size,
+        })
+    }
+}
+
+impl SchedulerMetricsCollector for PrometheusMetricsCollector {
+    fn record_submitted(&self, _job_id: &str, queued_at: u64, submitted_at: u64) {
+        self.submitted.inc();
+        self.planning_time
+            .observe((submitted_at - queued_at) as f64 / 1000_f64);
+    }
+
+    fn record_completed(&self, _job_id: &str, queued_at: u64, completed_at: u64) {
+        self.completed.inc();
+        self.execution_time
+            .observe((completed_at - queued_at) as f64)
+    }
+
+    fn record_failed(&self, _job_id: &str, _queued_at: u64, _failed_at: u64) {
+        self.failed.inc()
+    }
+
+    fn record_cancelled(&self, _job_id: &str) {
+        self.cancelled.inc();
+    }
+
+    fn set_pending_tasks_queue_size(&self, value: u64) {
+        self.pending_queue_size.set(value as f64);
+    }
+}
+
+pub fn get_metrics() -> Result<impl Reply> {
+    let encoder = TextEncoder::new();
+
+    let metric_families = prometheus::gather();
+    let mut buffer = vec![];
+    encoder.encode(&metric_families, &mut buffer).map_err(|e| {
+        BallistaError::Internal(format!("Error encoding prometheus metrics: {:?}", e))
+    })?;
+
+    Ok(warp::reply::with_header(
+        buffer,
+        CONTENT_TYPE,
+        encoder.format_type(),
+    ))
+}

--- a/ballista/scheduler/src/scheduler_server/event.rs
+++ b/ballista/scheduler/src/scheduler_server/event.rs
@@ -31,13 +31,32 @@ pub enum QueryStageSchedulerEvent {
         job_name: String,
         session_ctx: Arc<SessionContext>,
         plan: Box<LogicalPlan>,
+        queued_at: u64,
     },
-    JobSubmitted(String),
+    JobSubmitted {
+        job_id: String,
+        queued_at: u64,
+        submitted_at: u64,
+    },
     // For a job which failed during planning
-    JobPlanningFailed(String, String),
-    JobFinished(String),
+    JobPlanningFailed {
+        job_id: String,
+        fail_message: String,
+        queued_at: u64,
+        failed_at: u64,
+    },
+    JobFinished {
+        job_id: String,
+        queued_at: u64,
+        completed_at: u64,
+    },
     // For a job fails with its execution graph setting failed
-    JobRunningFailed(String, String),
+    JobRunningFailed {
+        job_id: String,
+        fail_message: String,
+        queued_at: u64,
+        failed_at: u64,
+    },
     JobUpdated(String),
     JobCancel(String),
     JobDataClean(String),

--- a/ballista/scheduler/src/scheduler_server/external_scaler.rs
+++ b/ballista/scheduler/src/scheduler_server/external_scaler.rs
@@ -57,7 +57,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExternalScaler
         Ok(Response::new(GetMetricsResponse {
             metric_values: vec![MetricValue {
                 metric_name: INFLIGHT_TASKS_METRIC_NAME.to_string(),
-                metric_value: 10000000, // A very high number to saturate the HPA
+                metric_value: self.pending_tasks() as i64,
             }],
         }))
     }

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -47,7 +47,7 @@ use crate::scheduler_server::event::QueryStageSchedulerEvent;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tonic::{Request, Response, Status};
 
-use crate::scheduler_server::SchedulerServer;
+use crate::scheduler_server::{timestamp_secs, SchedulerServer};
 use crate::state::executor_manager::ExecutorReservation;
 
 #[tonic::async_trait]
@@ -99,10 +99,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             };
             let executor_heartbeat = ExecutorHeartbeat {
                 executor_id: metadata.id.clone(),
-                timestamp: SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
-                    .as_secs(),
+                timestamp: timestamp_secs(),
                 metrics: vec![],
                 status: Some(ExecutorStatus {
                     status: Some(executor_status::Status::Active("".to_string())),
@@ -578,6 +575,7 @@ mod test {
     use tonic::Request;
 
     use crate::config::SchedulerConfig;
+    use crate::metrics::default_metrics_collector;
     use ballista_core::error::BallistaError;
     use ballista_core::serde::protobuf::{
         executor_registration::OptionalHost, executor_status, ExecutorRegistration,
@@ -602,6 +600,7 @@ mod test {
                 state_storage.clone(),
                 BallistaCodec::default(),
                 SchedulerConfig::default(),
+                default_metrics_collector().unwrap(),
             );
         scheduler.init().await?;
         let exec_meta = ExecutorRegistration {
@@ -688,6 +687,7 @@ mod test {
                 state_storage.clone(),
                 BallistaCodec::default(),
                 SchedulerConfig::default(),
+                default_metrics_collector().unwrap(),
             );
         scheduler.init().await?;
 
@@ -768,6 +768,7 @@ mod test {
                 state_storage.clone(),
                 BallistaCodec::default(),
                 SchedulerConfig::default(),
+                default_metrics_collector().unwrap(),
             );
         scheduler.init().await?;
 

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -143,6 +143,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         self.query_stage_scheduler.pending_tasks()
     }
 
+    pub(crate) fn metrics_collector(&self) -> &dyn SchedulerMetricsCollector {
+        self.query_stage_scheduler.metrics_collector()
+    }
+
     pub(crate) async fn submit_job(
         &self,
         job_id: &str,

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use log::{debug, error, info};
@@ -25,7 +24,7 @@ use ballista_core::error::{BallistaError, Result};
 use ballista_core::event_loop::{EventAction, EventSender};
 
 use crate::metrics::SchedulerMetricsCollector;
-use crate::scheduler_server::{timestamp_millis, timestamp_secs};
+use crate::scheduler_server::timestamp_millis;
 use ballista_core::serde::AsExecutionPlan;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use tokio::sync::mpsc;

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -71,6 +71,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageSchedul
     pub(crate) fn pending_tasks(&self) -> usize {
         self.pending_tasks.load(Ordering::SeqCst)
     }
+
+    pub(crate) fn metrics_collector(&self) -> &dyn SchedulerMetricsCollector {
+        self.metrics_collector.as_ref()
+    }
 }
 
 #[async_trait]

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -236,7 +236,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 self.inc_pending_tasks(new_tasks);
             }
             QueryStageSchedulerEvent::JobCancel(job_id) => {
-                println!("Cancelling job {}", job_id);
                 self.metrics_collector.record_cancelled(&job_id);
 
                 info!("Job {} Cancelled", job_id);
@@ -285,7 +284,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 let (reservations, assigned) =
                     self.state.offer_reservation(reservations).await?;
 
-                println!("Dec {} tasks", assigned);
                 self.dec_pending_tasks(assigned);
 
                 if !reservations.is_empty() {

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::config::SchedulerConfig;
+use crate::metrics::default_metrics_collector;
 use crate::{
     scheduler_server::SchedulerServer, state::backend::standalone::StandaloneClient,
 };
@@ -34,12 +35,15 @@ use tokio::net::TcpListener;
 pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
     let client = StandaloneClient::try_new_temporary()?;
 
+    let metrics_collector = default_metrics_collector()?;
+
     let mut scheduler_server: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =
         SchedulerServer::new(
             "localhost:50050".to_owned(),
             Arc::new(client),
             BallistaCodec::default(),
             SchedulerConfig::default(),
+            metrics_collector,
         );
     scheduler_server.init().await?;
     let server = SchedulerGrpcServer::new(scheduler_server.clone());

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -47,7 +47,7 @@ use ballista_core::serde::{AsExecutionPlan, BallistaCodec};
 use crate::display::print_stage_metrics;
 use crate::planner::DistributedPlanner;
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
-use crate::scheduler_server::{timestamp_millis, timestamp_secs};
+use crate::scheduler_server::timestamp_millis;
 pub(crate) use crate::state::execution_graph::execution_stage::{
     ExecutionStage, FailedStage, ResolvedStage, StageOutput, SuccessfulStage, TaskInfo,
     UnresolvedStage,

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -47,6 +47,7 @@ use ballista_core::serde::{AsExecutionPlan, BallistaCodec};
 use crate::display::print_stage_metrics;
 use crate::planner::DistributedPlanner;
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
+use crate::scheduler_server::{timestamp_millis, timestamp_secs};
 pub(crate) use crate::state::execution_graph::execution_stage::{
     ExecutionStage, FailedStage, ResolvedStage, StageOutput, SuccessfulStage, TaskInfo,
     UnresolvedStage,
@@ -110,6 +111,8 @@ pub struct ExecutionGraph {
     session_id: String,
     /// Status of this job
     status: JobStatus,
+    /// Timestamp of when this job was submitted
+    queued_at: u64,
     /// Job start time
     start_time: u64,
     /// Job end time
@@ -143,6 +146,7 @@ impl ExecutionGraph {
         job_name: &str,
         session_id: &str,
         plan: Arc<dyn ExecutionPlan>,
+        queued_at: u64,
     ) -> Result<Self> {
         let mut planner = DistributedPlanner::new();
 
@@ -161,10 +165,8 @@ impl ExecutionGraph {
             status: JobStatus {
                 status: Some(job_status::Status::Queued(QueuedJob {})),
             },
-            start_time: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64,
+            queued_at,
+            start_time: timestamp_millis(),
             end_time: 0,
             stages,
             output_partitions,
@@ -700,15 +702,21 @@ impl ExecutionGraph {
         if !updated_stages.failed_stages.is_empty() {
             info!("Job {} is failed", job_id);
             self.fail_job(job_err_msg.clone());
-            events.push(QueryStageSchedulerEvent::JobRunningFailed(
+            events.push(QueryStageSchedulerEvent::JobRunningFailed {
                 job_id,
-                job_err_msg,
-            ));
+                fail_message: job_err_msg,
+                queued_at: self.queued_at,
+                failed_at: timestamp_millis(),
+            });
         } else if self.is_successful() {
             // If this ExecutionGraph is successful, finish it
             info!("Job {} is success, finalizing output partitions", job_id);
             self.succeed_job()?;
-            events.push(QueryStageSchedulerEvent::JobFinished(job_id));
+            events.push(QueryStageSchedulerEvent::JobFinished {
+                job_id,
+                queued_at: self.queued_at,
+                completed_at: timestamp_millis(),
+            });
         } else if has_resolved {
             events.push(QueryStageSchedulerEvent::JobUpdated(job_id))
         }
@@ -1312,6 +1320,7 @@ impl ExecutionGraph {
                     "Invalid Execution Graph: missing job status".to_owned(),
                 )
             })?,
+            queued_at: proto.queued_at,
             start_time: proto.start_time,
             end_time: proto.end_time,
             stages,
@@ -1386,6 +1395,7 @@ impl ExecutionGraph {
             job_name: graph.job_name,
             session_id: graph.session_id,
             status: Some(graph.status),
+            queued_at: graph.queued_at,
             start_time: graph.start_time,
             end_time: graph.end_time,
             stages,
@@ -2229,7 +2239,7 @@ mod test {
                     assert_eq!(stage_events.len(), 1);
                     assert!(matches!(
                         stage_events[0],
-                        QueryStageSchedulerEvent::JobRunningFailed(_, _)
+                        QueryStageSchedulerEvent::JobRunningFailed { .. }
                     ));
                     // Stage 2 is still running
                     let running_stage = agg_graph.running_stages();
@@ -2719,7 +2729,7 @@ mod test {
         assert_eq!(stage_events.len(), 1);
         assert!(matches!(
             stage_events[0],
-            QueryStageSchedulerEvent::JobRunningFailed(_, _)
+            QueryStageSchedulerEvent::JobRunningFailed { .. }
         ));
 
         drain_tasks(&mut agg_graph)?;
@@ -2769,7 +2779,7 @@ mod test {
 
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
-        ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap()
+        ExecutionGraph::new("localhost:50050", "job", "", "session", plan, 0).unwrap()
     }
 
     async fn test_two_aggregations_plan(partition: usize) -> ExecutionGraph {
@@ -2797,7 +2807,7 @@ mod test {
 
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
-        ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap()
+        ExecutionGraph::new("localhost:50050", "job", "", "session", plan, 0).unwrap()
     }
 
     async fn test_coalesce_plan(partition: usize) -> ExecutionGraph {
@@ -2820,7 +2830,7 @@ mod test {
 
         let plan = ctx.create_physical_plan(&optimized_plan).await.unwrap();
 
-        ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap()
+        ExecutionGraph::new("localhost:50050", "job", "", "session", plan, 0).unwrap()
     }
 
     async fn test_join_plan(partition: usize) -> ExecutionGraph {
@@ -2861,8 +2871,8 @@ mod test {
 
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
-        let graph =
-            ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap();
+        let graph = ExecutionGraph::new("localhost:50050", "job", "", "session", plan, 0)
+            .unwrap();
 
         println!("{:?}", graph);
 
@@ -2886,8 +2896,8 @@ mod test {
 
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
-        let graph =
-            ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap();
+        let graph = ExecutionGraph::new("localhost:50050", "job", "", "session", plan, 0)
+            .unwrap();
 
         println!("{:?}", graph);
 
@@ -2911,8 +2921,8 @@ mod test {
 
         println!("{}", DisplayableExecutionPlan::new(plan.as_ref()).indent());
 
-        let graph =
-            ExecutionGraph::new("localhost:50050", "job", "", "session", plan).unwrap();
+        let graph = ExecutionGraph::new("localhost:50050", "job", "", "session", plan, 0)
+            .unwrap();
 
         println!("{:?}", graph);
 

--- a/ballista/scheduler/src/state/execution_graph_dot.rs
+++ b/ballista/scheduler/src/state/execution_graph_dot.rs
@@ -542,6 +542,6 @@ filter_expr="]
             .await?;
         let plan = df.to_logical_plan()?;
         let plan = ctx.create_physical_plan(&plan).await?;
-        ExecutionGraph::new("scheduler_id", "job_id", "job_name", "session_id", plan)
+        ExecutionGraph::new("scheduler_id", "job_id", "job_name", "session_id", plan, 0)
     }
 }

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -311,6 +311,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         job_name: &str,
         session_ctx: Arc<SessionContext>,
         plan: &LogicalPlan,
+        queued_at: u64,
     ) -> Result<()> {
         let start = Instant::now();
 
@@ -377,7 +378,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         );
 
         self.task_manager
-            .submit_job(job_id, job_name, &session_ctx.session_id(), plan)
+            .submit_job(job_id, job_name, &session_ctx.session_id(), plan, queued_at)
             .await?;
 
         let elapsed = start.elapsed();
@@ -525,19 +526,43 @@ mod test {
         // Create 4 jobs so we have four pending tasks
         state
             .task_manager
-            .submit_job("job-1", "", session_ctx.session_id().as_str(), plan.clone())
+            .submit_job(
+                "job-1",
+                "",
+                session_ctx.session_id().as_str(),
+                plan.clone(),
+                0,
+            )
             .await?;
         state
             .task_manager
-            .submit_job("job-2", "", session_ctx.session_id().as_str(), plan.clone())
+            .submit_job(
+                "job-2",
+                "",
+                session_ctx.session_id().as_str(),
+                plan.clone(),
+                0,
+            )
             .await?;
         state
             .task_manager
-            .submit_job("job-3", "", session_ctx.session_id().as_str(), plan.clone())
+            .submit_job(
+                "job-3",
+                "",
+                session_ctx.session_id().as_str(),
+                plan.clone(),
+                0,
+            )
             .await?;
         state
             .task_manager
-            .submit_job("job-4", "", session_ctx.session_id().as_str(), plan.clone())
+            .submit_job(
+                "job-4",
+                "",
+                session_ctx.session_id().as_str(),
+                plan.clone(),
+                0,
+            )
             .await?;
 
         let executors = test_executors(1, 4);
@@ -582,7 +607,13 @@ mod test {
         // Create a job
         state
             .task_manager
-            .submit_job("job-1", "", session_ctx.session_id().as_str(), plan.clone())
+            .submit_job(
+                "job-1",
+                "",
+                session_ctx.session_id().as_str(),
+                plan.clone(),
+                0,
+            )
             .await?;
 
         let executors = test_executors(1, 4);

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -387,26 +387,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         Ok(())
     }
 
-    pub(crate) async fn cancel_job(&self, job_id: &str) -> Result<bool> {
-        info!("Received cancellation request for job {}", job_id);
-
-        match self.task_manager.cancel_job(job_id).await {
-            Ok(tasks) => {
-                self.executor_manager.cancel_running_tasks(tasks).await.map_err(|e| {
-                        let msg = format!("Error to cancel running tasks when cancelling job {} due to {:?}", job_id, e);
-                        error!("{}", msg);
-                        BallistaError::Internal(msg)
-                })?;
-                Ok(true)
-            }
-            Err(e) => {
-                let msg = format!("Error cancelling job {}: {:?}", job_id, e);
-                error!("{}", msg);
-                Ok(false)
-            }
-        }
-    }
-
     /// Spawn a delayed future to clean up job data on both Scheduler and Executors
     pub(crate) fn clean_up_successful_job(&self, job_id: String) {
         self.executor_manager.clean_up_job_data_delayed(

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -203,7 +203,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         &self,
         reservations: Vec<ExecutorReservation>,
     ) -> Result<(Vec<ExecutorReservation>, usize)> {
-        let num_reservations = reservations.len();
+        let mut assigned = 0;
 
         let (free_list, pending_tasks) = match self
             .task_manager
@@ -267,6 +267,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
                                         ),
                                     );
                                 }
+                            } else {
+                                assigned += n_tasks;
                             }
                         }
                         Err(e) => {
@@ -286,8 +288,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
                 (reservations, 0)
             }
         };
-
-        let assigned = num_reservations - free_list.len();
 
         let mut new_reservations = vec![];
         if !free_list.is_empty() {

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -135,7 +135,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         }
     }
 
-    #[cfg(test)]
+    #[allow(dead_code)]
     pub(crate) fn with_task_launcher(
         config_client: Arc<dyn StateBackendClient>,
         session_builder: SessionBuilder,

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -119,9 +119,16 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         job_name: &str,
         session_id: &str,
         plan: Arc<dyn ExecutionPlan>,
+        queued_at: u64,
     ) -> Result<()> {
-        let mut graph =
-            ExecutionGraph::new(&self.scheduler_id, job_id, job_name, session_id, plan)?;
+        let mut graph = ExecutionGraph::new(
+            &self.scheduler_id,
+            job_id,
+            job_name,
+            session_id,
+            plan,
+            queued_at,
+        )?;
         info!("Submitting execution graph: {:?}", graph);
         self.state
             .put(

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -371,7 +371,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                 }
             }
             if assign_tasks >= free_reservations.len() {
-                pending_tasks = graph.available_tasks();
+                pending_tasks += graph.available_tasks();
                 break;
             }
         }

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -29,7 +29,7 @@ use ballista_core::error::Result;
 
 use crate::state::backend::Keyspace::{CompletedJobs, FailedJobs};
 use crate::state::session_manager::create_datafusion_context;
-use async_trait::async_trait;
+
 use ballista_core::serde::protobuf::{
     self, job_status, FailedJob, JobStatus, MultiTaskDefinition, TaskDefinition, TaskId,
     TaskStatus,
@@ -159,6 +159,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn with_launcher(
         state: Arc<dyn StateBackendClient>,
         session_builder: SessionBuilder,
@@ -556,45 +557,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         })
         .await
     }
-
-    // #[allow(dead_code)]
-    // #[cfg(not(test))]
-    // /// Launch the given task on the specified executor
-    // pub(crate) async fn launch_task(
-    //     &self,
-    //     executor: &ExecutorMetadata,
-    //     task: TaskDescription,
-    //     executor_manager: &ExecutorManager,
-    // ) -> Result<()> {
-    //     info!("Launching task {:?} on executor {:?}", task, executor.id);
-    //     let task_definition = self.prepare_task_definition(task)?;
-    //     let mut client = executor_manager.get_client(&executor.id).await?;
-    //     client
-    //         .launch_task(protobuf::LaunchTaskParams {
-    //             tasks: vec![task_definition],
-    //             scheduler_id: self.scheduler_id.clone(),
-    //         })
-    //         .await
-    //         .map_err(|e| {
-    //             BallistaError::Internal(format!(
-    //                 "Failed to connect to executor {}: {:?}",
-    //                 executor.id, e
-    //             ))
-    //         })?;
-    //     Ok(())
-    // }
-    //
-    // #[allow(dead_code)]
-    // #[cfg(test)]
-    // /// In unit tests, we do not have actual executors running, so it simplifies things to just noop.
-    // pub(crate) async fn launch_task(
-    //     &self,
-    //     _executor: &ExecutorMetadata,
-    //     _task: TaskDescription,
-    //     _executor_manager: &ExecutorManager,
-    // ) -> Result<()> {
-    //     Ok(())
-    // }
 
     /// Retrieve the number of available tasks for the given job. The value returned
     /// is strictly a point-in-time snapshot

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -666,6 +666,10 @@ impl SchedulerMetricsCollector for TestMetricsCollector {
     }
 
     fn set_pending_tasks_queue_size(&self, _value: u64) {}
+
+    fn gather_metrics(&self) -> Result<Option<(Vec<u8>, String)>> {
+        Ok(None)
+    }
 }
 
 pub fn assert_submitted_event(job_id: &str, collector: &TestMetricsCollector) {

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -15,21 +15,44 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use ballista_core::error::Result;
+use ballista_core::error::{BallistaError, Result};
 use std::any::Any;
+use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 
+use crate::config::SchedulerConfig;
+use crate::metrics::SchedulerMetricsCollector;
+use crate::scheduler_server::{timestamp_millis, SchedulerServer};
+use crate::state::backend::standalone::StandaloneClient;
+use crate::state::execution_graph::ExecutionGraph;
+use crate::state::executor_manager::ExecutorManager;
+use crate::state::task_manager::TaskLauncher;
+use crate::state::SchedulerState;
+use ballista_core::config::{BallistaConfig, BALLISTA_DEFAULT_SHUFFLE_PARTITIONS};
+use ballista_core::serde::protobuf::job_status::Status;
+use ballista_core::serde::protobuf::scheduler_grpc_server::SchedulerGrpc;
+use ballista_core::serde::protobuf::{
+    task_status, JobStatus, MultiTaskDefinition, PhysicalPlanNode, ShuffleWritePartition,
+    SuccessfulTask, TaskId, TaskStatus,
+};
+use ballista_core::serde::scheduler::{
+    ExecutorData, ExecutorMetadata, ExecutorSpecification,
+};
+use ballista_core::serde::{AsExecutionPlan, BallistaCodec};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::common::DataFusionError;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::execution::context::{SessionConfig, SessionContext, SessionState};
-use datafusion::logical_expr::Expr;
+use datafusion::logical_expr::{Expr, LogicalPlan};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::CsvReadOptions;
+use datafusion_proto::logical_plan::AsLogicalPlan;
+use datafusion_proto::protobuf::LogicalPlanNode;
+use tokio::sync::mpsc::{channel, Sender};
 
 pub const TPCH_TABLES: &[&str] = &[
     "part", "supplier", "partsupp", "customer", "orders", "lineitem", "nation", "region",
@@ -199,5 +222,294 @@ pub fn get_tpch_schema(table: &str) -> Schema {
         ]),
 
         _ => unimplemented!(),
+    }
+}
+
+pub trait TaskRunner: Send + Sync + 'static {
+    fn run(&self, executor_id: String, tasks: MultiTaskDefinition) -> Vec<TaskStatus>;
+}
+
+#[derive(Clone)]
+pub struct TaskRunnerFn<F> {
+    f: F,
+}
+
+impl<F> TaskRunnerFn<F>
+where
+    F: Fn(String, MultiTaskDefinition) -> Vec<TaskStatus> + Send + Sync + 'static,
+{
+    pub fn new(f: F) -> Self {
+        Self { f }
+    }
+}
+
+impl<F> TaskRunner for TaskRunnerFn<F>
+where
+    F: Fn(String, MultiTaskDefinition) -> Vec<TaskStatus> + Send + Sync + 'static,
+{
+    fn run(&self, executor_id: String, tasks: MultiTaskDefinition) -> Vec<TaskStatus> {
+        (self.f)(executor_id, tasks)
+    }
+}
+
+pub fn default_task_runner() -> impl TaskRunner {
+    TaskRunnerFn::new(|executor_id: String, task: MultiTaskDefinition| {
+        let mut statuses = vec![];
+
+        let partitions =
+            if let Some(output_partitioning) = task.output_partitioning.as_ref() {
+                output_partitioning.partition_count as usize
+            } else {
+                1
+            };
+
+        let partitions: Vec<ShuffleWritePartition> = (0..partitions)
+            .into_iter()
+            .map(|i| ShuffleWritePartition {
+                partition_id: i as u64,
+                path: String::default(),
+                num_batches: 1,
+                num_rows: 1,
+                num_bytes: 1,
+            })
+            .collect();
+
+        for TaskId {
+            task_id,
+            partition_id,
+            ..
+        } in task.task_ids
+        {
+            let timestamp = timestamp_millis();
+            statuses.push(TaskStatus {
+                task_id,
+                job_id: task.job_id.clone(),
+                stage_id: task.stage_id,
+                stage_attempt_num: task.stage_attempt_num,
+                partition_id,
+                launch_time: timestamp,
+                start_exec_time: timestamp,
+                end_exec_time: timestamp,
+                metrics: vec![],
+                status: Some(task_status::Status::Successful(SuccessfulTask {
+                    executor_id: executor_id.clone(),
+                    partitions: partitions.clone(),
+                })),
+            });
+        }
+
+        statuses
+    })
+}
+
+#[derive(Clone)]
+struct VirtualExecutor {
+    executor_id: String,
+    task_slots: usize,
+    runner: Arc<dyn TaskRunner>,
+}
+
+impl VirtualExecutor {
+    pub fn run_tasks(&self, tasks: MultiTaskDefinition) -> Vec<TaskStatus> {
+        self.runner.run(self.executor_id.clone(), tasks)
+    }
+}
+
+/// Launcher which consumes tasks and never sends a status update
+#[derive(Default)]
+pub struct BlackholeTaskLauncher {}
+
+#[async_trait]
+impl TaskLauncher for BlackholeTaskLauncher {
+    async fn launch_tasks(
+        &self,
+        _executor: &ExecutorMetadata,
+        _tasks: Vec<MultiTaskDefinition>,
+        _executor_manager: &ExecutorManager,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub struct VirtualTaskLauncher {
+    sender: Sender<(String, Vec<TaskStatus>)>,
+    executors: HashMap<String, VirtualExecutor>,
+}
+
+#[async_trait::async_trait]
+impl TaskLauncher for VirtualTaskLauncher {
+    async fn launch_tasks(
+        &self,
+        executor: &ExecutorMetadata,
+        tasks: Vec<MultiTaskDefinition>,
+        _executor_manager: &ExecutorManager,
+    ) -> Result<()> {
+        let virtual_executor = self.executors.get(&executor.id).ok_or_else(|| {
+            BallistaError::Internal(format!(
+                "No virtual executor with ID {} found",
+                executor.id
+            ))
+        })?;
+
+        let status = tasks
+            .into_iter()
+            .flat_map(|t| virtual_executor.run_tasks(t))
+            .collect();
+
+        self.sender
+            .send((executor.id.clone(), status))
+            .await
+            .map_err(|e| {
+                BallistaError::Internal(format!("Error sending task status: {:?}", e))
+            })
+    }
+}
+
+pub struct SchedulerTest {
+    scheduler: SchedulerServer<LogicalPlanNode, PhysicalPlanNode>,
+    ballista_config: BallistaConfig,
+}
+
+impl SchedulerTest {
+    pub async fn new(
+        config: SchedulerConfig,
+        metrics_collector: Arc<dyn SchedulerMetricsCollector>,
+        num_executors: usize,
+        task_slots_per_executor: usize,
+        runner: Option<Arc<dyn TaskRunner>>,
+    ) -> Result<Self> {
+        let state_storage = Arc::new(StandaloneClient::try_new_temporary()?);
+
+        let ballista_config = BallistaConfig::builder()
+            .set(
+                BALLISTA_DEFAULT_SHUFFLE_PARTITIONS,
+                format!("{}", num_executors * task_slots_per_executor).as_str(),
+            )
+            .build()
+            .expect("creating BallistaConfig");
+
+        let runner = runner.unwrap_or_else(|| Arc::new(default_task_runner()));
+
+        let executors: HashMap<String, VirtualExecutor> = (0..num_executors)
+            .into_iter()
+            .map(|i| {
+                let id = format!("virtual-executor-{}", i);
+                let executor = VirtualExecutor {
+                    executor_id: id.clone(),
+                    task_slots: task_slots_per_executor,
+                    runner: runner.clone(),
+                };
+                (id, executor)
+            })
+            .collect();
+
+        let (sender, mut receiver) = channel(1000);
+
+        let launcher = VirtualTaskLauncher {
+            sender,
+            executors: executors.clone(),
+        };
+
+        let mut scheduler: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =
+            SchedulerServer::with_task_launcher(
+                "localhost:50050".to_owned(),
+                state_storage.clone(),
+                BallistaCodec::default(),
+                config,
+                metrics_collector,
+                Arc::new(launcher),
+            );
+        scheduler.init().await?;
+
+        for (executor_id, VirtualExecutor { task_slots, .. }) in executors {
+            let metadata = ExecutorMetadata {
+                id: executor_id.clone(),
+                host: String::default(),
+                port: 0,
+                grpc_port: 0,
+                specification: ExecutorSpecification {
+                    task_slots: task_slots as u32,
+                },
+            };
+
+            let executor_data = ExecutorData {
+                executor_id,
+                total_task_slots: task_slots as u32,
+                available_task_slots: task_slots as u32,
+            };
+
+            scheduler
+                .state
+                .executor_manager
+                .register_executor(metadata, executor_data, false)
+                .await?;
+        }
+
+        let scheduler_clone = scheduler.clone();
+
+        tokio::spawn(async move {
+            while let Some((executor_id, status)) = receiver.recv().await {
+                scheduler_clone
+                    .update_task_status(&executor_id, status)
+                    .await
+                    .unwrap();
+            }
+        });
+
+        Ok(Self {
+            scheduler,
+            ballista_config,
+        })
+    }
+
+    pub async fn ctx(&self) -> Result<Arc<SessionContext>> {
+        self.scheduler
+            .state
+            .session_manager
+            .create_session(&self.ballista_config)
+            .await
+    }
+
+    pub async fn run(
+        &self,
+        job_id: &str,
+        job_name: &str,
+        plan: &LogicalPlan,
+    ) -> Result<JobStatus> {
+        let ctx = self
+            .scheduler
+            .state
+            .session_manager
+            .create_session(&self.ballista_config)
+            .await?;
+
+        self.scheduler
+            .submit_job(job_id, job_name, ctx, plan)
+            .await?;
+
+        let final_status: Result<JobStatus> = loop {
+            let status = self
+                .scheduler
+                .state
+                .task_manager
+                .get_job_status(job_id)
+                .await?;
+
+            if let Some(JobStatus {
+                status: Some(inner),
+            }) = status.as_ref()
+            {
+                match inner {
+                    Status::Failed(_) | Status::Successful(_) => {
+                        break Ok(status.unwrap())
+                    }
+                    _ => continue,
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await
+        };
+
+        final_status
     }
 }

--- a/docs/source/user-guide/metrics.md
+++ b/docs/source/user-guide/metrics.md
@@ -19,22 +19,23 @@
 
 # Ballista Scheduler Metrics
 
-## Prometheus 
+## Prometheus
 
 Built with default features, the ballista scheduler will automatically collect and expose a standard set of prometheus metrics.
 The metrics currently collected automatically include:
-- *job_exec_time_seconds* - Histogram of successful job execution time in seconds
-- *planning_time_ms* - Histogram of job planning time in milliseconds
-- *failed* - Counter of failed jobs
-- *job_failed_total* - Counter of failed jobs
-- *job_cancelled_total* - Counter of cancelled jobs 
-- *job_completed_total* - Counter of completed jobs
-- *job_submitted_total* - Counter of submitted jobs 
-- *pending_task_queue_size* - Number of pending tasks
 
-**NOTE** Currently the histogram buckets for the above metrics are set to reasonable defaults. If the defaults are not 
+- _job_exec_time_seconds_ - Histogram of successful job execution time in seconds
+- _planning_time_ms_ - Histogram of job planning time in milliseconds
+- _failed_ - Counter of failed jobs
+- _job_failed_total_ - Counter of failed jobs
+- _job_cancelled_total_ - Counter of cancelled jobs
+- _job_completed_total_ - Counter of completed jobs
+- _job_submitted_total_ - Counter of submitted jobs
+- _pending_task_queue_size_ - Number of pending tasks
+
+**NOTE** Currently the histogram buckets for the above metrics are set to reasonable defaults. If the defaults are not
 appropriate for a given use case, the only workaround is to implement a customer `SchedulerMetricsCollector`. In the future
-the buckets should be made configurable. 
+the buckets should be made configurable.
 
 The metrics are then exported through the scheduler REST API at `GET /api/metrics`. It should be sufficient to ingest metrics
-into an existing metrics system by point your chosen prometheus exporter at that endpoint. 
+into an existing metrics system by point your chosen prometheus exporter at that endpoint.

--- a/docs/source/user-guide/metrics.md
+++ b/docs/source/user-guide/metrics.md
@@ -1,0 +1,40 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Ballista Scheduler Metrics
+
+## Prometheus 
+
+Built with default features, the ballista scheduler will automatically collect and expose a standard set of prometheus metrics.
+The metrics currently collected automatically include:
+- *job_exec_time_seconds* - Histogram of successful job execution time in seconds
+- *planning_time_ms* - Histogram of job planning time in milliseconds
+- *failed* - Counter of failed jobs
+- *job_failed_total* - Counter of failed jobs
+- *job_cancelled_total* - Counter of cancelled jobs 
+- *job_completed_total* - Counter of completed jobs
+- *job_submitted_total* - Counter of submitted jobs 
+- *pending_task_queue_size* - Number of pending tasks
+
+**NOTE** Currently the histogram buckets for the above metrics are set to reasonable defaults. If the defaults are not 
+appropriate for a given use case, the only workaround is to implement a customer `SchedulerMetricsCollector`. In the future
+the buckets should be made configurable. 
+
+The metrics are then exported through the scheduler REST API at `GET /api/metrics`. It should be sufficient to ingest metrics
+into an existing metrics system by point your chosen prometheus exporter at that endpoint. 

--- a/docs/source/user-guide/scheduler.md
+++ b/docs/source/user-guide/scheduler.md
@@ -29,9 +29,10 @@ The scheduler provides a web user interface that allows queries to be monitored.
 
 The scheduler also provides a REST API that allows jobs to be monitored.
 
-| API                   | Method | Description                                                 |
-| --------------------- | ------ | ----------------------------------------------------------- |
-| /api/jobs             | GET    | Get a list of jobs that have been submitted to the cluster. |
-| /api/job/{job_id}     | GET    | Get a summary of a submitted job.                           |
-| /api/job/{job_id}/dot | GET    | Produce a query plan in DOT (graphviz) format.              |
-| /api/job/{job_id}     | PATCH  | Cancel a currently running job                              |
+| API                    | Method | Description                                                  |
+|------------------------|--------|--------------------------------------------------------------|
+| /api/jobs              | GET    | Get a list of jobs that have been submitted to the cluster.  |
+| /api/job/{job_id}      | GET    | Get a summary of a submitted job.                            |
+| /api/job/{job_id}/dot  | GET    | Produce a query plan in DOT (graphviz) format.               |
+| /api/job/{job_id}      | PATCH  | Cancel a currently running job                               |
+ | /api/metrics           | GET    | Return current scheduler metric set                          | 

--- a/docs/source/user-guide/scheduler.md
+++ b/docs/source/user-guide/scheduler.md
@@ -29,10 +29,10 @@ The scheduler provides a web user interface that allows queries to be monitored.
 
 The scheduler also provides a REST API that allows jobs to be monitored.
 
-| API                    | Method | Description                                                  |
-|------------------------|--------|--------------------------------------------------------------|
-| /api/jobs              | GET    | Get a list of jobs that have been submitted to the cluster.  |
-| /api/job/{job_id}      | GET    | Get a summary of a submitted job.                            |
-| /api/job/{job_id}/dot  | GET    | Produce a query plan in DOT (graphviz) format.               |
-| /api/job/{job_id}      | PATCH  | Cancel a currently running job                               |
- | /api/metrics           | GET    | Return current scheduler metric set                          | 
+| API                   | Method | Description                                                 |
+| --------------------- | ------ | ----------------------------------------------------------- |
+| /api/jobs             | GET    | Get a list of jobs that have been submitted to the cluster. |
+| /api/job/{job_id}     | GET    | Get a summary of a submitted job.                           |
+| /api/job/{job_id}/dot | GET    | Produce a query plan in DOT (graphviz) format.              |
+| /api/job/{job_id}     | PATCH  | Cancel a currently running job                              |
+| /api/metrics          | GET    | Return current scheduler metric set                         |


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #504 
Closes #507 

Depends on https://github.com/apache/arrow-ballista/pull/504

~~Posting this for review now, the functionality is done but I also want to address https://github.com/apache/arrow-ballista/issues/507 here. If I can't get to that before this is approved it's fine to merge and I can add the user guide in a separate PR.~~

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Track the size of the pending task queue in the scheduler and expose through both prometheus metrics and the external scaler service. 

The number of pending tasks is the number of tasks that can be scheduled but for which there is no executor slot to schedule it on (i.e. it does not count tasks for unresolved stages, etc). 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add a `pending_tasks` state to the `QueryStageScheduler` and track the value in response to scheduler events. 

I also added some more bells and whistles to the `SchedulerTest` utility introduced in the previous PR. We can now submit a job and control when "virtual" executors send their task updates so we have finer-grained control to test different scenarios. 

Added a rudimentary user guide. 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

The external scaler service should now return the actual number of pending tasks instead of a hard-coded value. Also, the pending task queue size should be available in the prometheus metrics. 

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No
