### PR TITLE
Fix Helm chart's image format

### DIFF
--- a/helm/ballista/templates/executor.yaml
+++ b/helm/ballista/templates/executor.yaml
@@ -50,7 +50,7 @@ spec:
         - name: {{ .Chart.Name }}-executor
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}{{ .Values.image.executor }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}/{{ .Values.image.executor }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/root/ballista-executor", "--scheduler-host=ballista-scheduler"]
           env:

--- a/helm/ballista/templates/scheduler.yaml
+++ b/helm/ballista/templates/scheduler.yaml
@@ -50,7 +50,7 @@ spec:
         - name: {{ .Chart.Name }}-scheduler
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}{{ .Values.image.scheduler }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}/{{ .Values.image.scheduler }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: AWS_DEFAULT_REGION

--- a/helm/ballista/values.yaml
+++ b/helm/ballista/values.yaml
@@ -20,7 +20,7 @@ image:
   repository: ""
   scheduler: ballista-scheduler
   executor: ballista-executor
-  pullPolicy: Never
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 


### PR DESCRIPTION

 # Rationale for this change

Fix the Helm chart's image format.

Currently `andygroveballista-scheduler:latest`
after this change
will be `andygrove/ballista-scheduler:latest`

if we set the repo as `andygrove`

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
