### PR TITLE
Support Alibaba Cloud OSS with ObjectStore

### DIFF
--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -58,7 +58,7 @@ hashbrown = "0.13"
 itertools = "0.10"
 libloading = "0.7.3"
 log = "0.4"
-object_store = "0.5.0"
+object_store = "0.5.2"
 once_cell = "1.9.0"
 
 parking_lot = "0.12"

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -99,9 +99,20 @@ impl ObjectStoreProvider for FeatureBasedObjectStoreProvider {
 
         #[cfg(feature = "s3")]
         {
-            if url.to_string().starts_with("s3://") {
+            if url.as_str().starts_with("s3://") {
                 if let Some(bucket_name) = url.host_str() {
                     let store = AmazonS3Builder::from_env()
+                        .with_bucket_name(bucket_name)
+                        .build()?;
+                    return Ok(Arc::new(store));
+                }
+            // Support Alibaba Cloud OSS
+            // Use S3 compatibility mode to access Alibaba Cloud OSS
+            // The `AWS_ENDPOINT` should have bucket name included
+            } else if url.as_str().starts_with("oss://") {
+                if let Some(bucket_name) = url.host_str() {
+                    let store = AmazonS3Builder::from_env()
+                        .with_virtual_hosted_style_request(true)
                         .with_bucket_name(bucket_name)
                         .build()?;
                     return Ok(Arc::new(store));


### PR DESCRIPTION
# Which issue does this PR close?

Closes #566 

 # Rationale for this change

See #566 

# What changes are included in this PR?
* update object_store version to "0.5.2"
* support `oss://` url in `FeatureBasedObjectStoreProvider`


# Are there any user-facing changes?
None
