### PR TITLE
updated readme to contain correct versions of dependencies.

### DIFF
--- a/ballista/client/README.md
+++ b/ballista/client/README.md
@@ -84,8 +84,8 @@ To build a simple ballista example, add the following dependencies to your `Carg
 
 ```toml
 [dependencies]
-ballista = "0.8"
-datafusion = "12.0.0"
+ballista = "0.10"
+datafusion = "14.0.0"
 tokio = "1.0"
 ```
 


### PR DESCRIPTION
The Readme that we get redirected to from Getting Started Guide contains older versions for dependencies. Running the examples with the current versions fails. This PR fixes that.