### PR TITLE
repartition push-down

### DIFF
--- a/ballista/scheduler/src/physical_optimizer/avoid_repartition.rs
+++ b/ballista/scheduler/src/physical_optimizer/avoid_repartition.rs
@@ -1,0 +1,125 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Rule to push hash partitioning down and replace round-robin partitioning
+
+use std::sync::Arc;
+
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::{ExecutionPlan, Partitioning, with_new_children_if_necessary};
+use datafusion::physical_plan::aggregates::AggregateExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::windows::WindowAggExec;
+use datafusion::prelude::SessionConfig;
+use datafusion::common::Result;
+
+/// This rule attempts to push hash repartitions (usually introduced to facilitate hash partitioned
+/// joins) down to the table scan and replace any round-robin partitioning that exists. It is
+/// wasteful to perform round-robin partition first only to repartition later for the join. It is
+/// more efficient to just partition by the join key(s) right away.
+#[derive(Default)]
+pub struct AvoidRepartition {}
+
+impl PhysicalOptimizerRule for AvoidRepartition {
+
+    fn name(&self) -> &str {
+        "avoid_repartition"
+    }
+
+    fn optimize(&self, plan: Arc<dyn ExecutionPlan>, _config: &SessionConfig) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        remove_redundant_repartitioning(plan, None)
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+fn remove_redundant_repartitioning(
+    plan: Arc<dyn ExecutionPlan>,
+    partitioning: Option<Partitioning>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    if let Some(repart) = plan.as_any().downcast_ref::<RepartitionExec>() {
+        match repart.partitioning() {
+            Partitioning::RoundRobinBatch(_) => {
+                match partitioning {
+                    Some(Partitioning::Hash(expr, n)) => {
+                        // check that all partition columns are resolvable
+                        if expr.iter().all(|e| {
+                            if let Some(x) = e.as_any().downcast_ref::<Column>() {
+                                repart.schema().column_with_name(x.name()).is_some()
+                            } else {
+                                false
+                            }
+                        }) {
+                            // drop the round-robin repartition and replace with the hash partitioning
+                            Ok(Arc::new(RepartitionExec::try_new(
+                                plan.children()[0].clone(),
+                                Partitioning::Hash(expr.clone(), n),
+                            )?))
+                        } else {
+                            Ok(plan.clone())
+                        }
+                    }
+                    _ => Ok(plan.clone())
+                }
+            }
+            Partitioning::Hash(expr, _) => {
+                // we only attempt to push hash-partitioning down if the hash expressions
+                // are simple column references
+                if expr.iter().all(|e| e.as_any().downcast_ref::<Column>().is_some()) {
+                    let p = repart.partitioning().clone();
+                    let new_plan = optimize_children(plan, Some(p.clone()))?;
+                    if new_plan.children()[0].output_partitioning() == p {
+                        // drop this hash partitioning if we pushed it down
+                        Ok(new_plan.children()[0].clone())
+                    } else {
+                        Ok(new_plan)
+                    }
+                } else {
+                    Ok(plan.clone())
+                }
+            }
+            _ => optimize_children(plan, partitioning),
+        }
+    } else if plan.as_any().downcast_ref::<AggregateExec>().is_some()
+        || plan.as_any().downcast_ref::<WindowAggExec>().is_some() /*
+        || plan.as_any().downcast_ref::<BoundedWindowAggExec>().is_some()*/ {
+        // skip these
+        Ok(plan.clone())
+    } else {
+        optimize_children(plan, partitioning)
+    }
+}
+
+fn optimize_children(
+    plan: Arc<dyn ExecutionPlan>,
+    partitioning: Option<Partitioning>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let inputs = plan.children();
+    if inputs.is_empty() {
+        return Ok(plan.clone());
+    }
+    let mut new_inputs = vec![];
+    for input in &inputs {
+        let new_input =
+            remove_redundant_repartitioning(input.clone(), partitioning.clone())?;
+        new_inputs.push(new_input);
+    }
+    with_new_children_if_necessary(plan, new_inputs).map_err(|e| e.into())
+}

--- a/ballista/scheduler/src/physical_optimizer/mod.rs
+++ b/ballista/scheduler/src/physical_optimizer/mod.rs
@@ -15,20 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![doc = include_str ! ("../README.md")]
-
-pub mod api;
-pub mod config;
-pub mod display;
-pub mod metrics;
-pub mod planner;
-pub mod scheduler_server;
-#[cfg(feature = "sled")]
-pub mod standalone;
-pub mod state;
-pub(crate) mod physical_optimizer;
-
-#[cfg(feature = "flight-sql")]
-pub mod flight_sql;
-#[cfg(test)]
-pub mod test_utils;
+pub(crate) mod avoid_repartition;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-ballista/issues/608

 
See issue for full description of the problem that this PR resolves.

# Rationale for this change

Why repartition twice when we can repartition once?

## Before

Before this PR we have 2 instances of `RepartitionExec` in the plan for each table that is an input to a join.

```
CoalesceBatchesExec: target_batch_size=8192, metrics=[output_rows=0, elapsed_compute=20.396µs, spill_count=0, spilled_bytes=0, mem_used=0]
  RepartitionExec: partitioning=Hash([Column { name: "r_regionkey", index: 0 }], 48), metrics=[fetch_time=69.603684ms, send_time=48ns, repart_time=48ns]
    RepartitionExec: partitioning=RoundRobinBatch(48), metrics=[fetch_time=479.696µs, send_time=1ns, repart_time=1ns]
      CoalesceBatchesExec: target_batch_size=8192, metrics=[output_rows=0, elapsed_compute=320ns, spill_count=0, spilled_bytes=0, mem_used=0]
        FilterExec: r_name@1 = EUROPE, metrics=[output_rows=0, elapsed_compute=1ns, spill_count=0, spilled_bytes=0, mem_used=0]
          ParquetExec: ...
```

## After

With this PR we only have 1 instance of RepartitionExec

```
CoalesceBatchesExec: target_batch_size=8192, metrics=[output_rows=0, elapsed_compute=6.855µs, spill_count=0, spilled_bytes=0, mem_used=0]
  RepartitionExec: partitioning=Hash([Column { name: "r_regionkey", index: 0 }], 48), metrics=[fetch_time=322.318µs, send_time=1ns, repart_time=1ns]
    CoalesceBatchesExec: target_batch_size=8192, metrics=[output_rows=0, elapsed_compute=281ns, spill_count=0, spilled_bytes=0, mem_used=0]
      FilterExec: r_name@1 = EUROPE, metrics=[output_rows=0, elapsed_compute=1ns, spill_count=0, spilled_bytes=0, mem_used=0]
        ParquetExec: ...
```

# What changes are included in this PR?

New physical optimizer rule

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
