### PR TITLE
Add executor terminating status for graceful shutdown

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -323,6 +323,7 @@ message ExecutorStatus {
     string active = 1;
     string dead = 2;
     string unknown = 3;
+    string terminating = 4;
   }
 }
 

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -540,7 +540,7 @@ pub mod executor_metric {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorStatus {
-    #[prost(oneof = "executor_status::Status", tags = "1, 2, 3")]
+    #[prost(oneof = "executor_status::Status", tags = "1, 2, 3, 4")]
     pub status: ::core::option::Option<executor_status::Status>,
 }
 /// Nested message and enum types in `ExecutorStatus`.
@@ -554,6 +554,8 @@ pub mod executor_status {
         Dead(::prost::alloc::string::String),
         #[prost(string, tag = "3")]
         Unknown(::prost::alloc::string::String),
+        #[prost(string, tag = "4")]
+        Terminating(::prost::alloc::string::String),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -19,7 +19,10 @@
 
 use dashmap::DashMap;
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use crate::metrics::ExecutorMetricsCollector;
 use ballista_core::error::BallistaError;
@@ -36,6 +39,20 @@ use datafusion::physical_plan::{ExecutionPlan, Partitioning};
 use futures::future::AbortHandle;
 
 use ballista_core::serde::scheduler::PartitionId;
+
+pub struct TasksDrainedFuture(pub Arc<Executor>);
+
+impl Future for TasksDrainedFuture {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.0.abort_handles.len() > 0 {
+            Poll::Pending
+        } else {
+            Poll::Ready(())
+        }
+    }
+}
 
 type AbortHandles = Arc<DashMap<(usize, PartitionId), AbortHandle>>;
 
@@ -174,6 +191,10 @@ impl Executor {
 
     pub fn work_dir(&self) -> &str {
         &self.work_dir
+    }
+
+    pub fn active_task_count(&self) -> usize {
+        self.abort_handles.len()
     }
 }
 

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -18,6 +18,7 @@
 //! Ballista Executor Process
 
 use std::net::SocketAddr;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{env, io};
@@ -41,18 +42,21 @@ use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
 
 use ballista_core::config::{LogRotationPolicy, TaskSchedulingPolicy};
 use ballista_core::error::BallistaError;
+use ballista_core::serde::protobuf::executor_resource::Resource;
+use ballista_core::serde::protobuf::executor_status::Status;
 use ballista_core::serde::protobuf::{
     executor_registration, scheduler_grpc_client::SchedulerGrpcClient,
-    ExecutorRegistration, ExecutorStoppedParams,
+    ExecutorRegistration, ExecutorResource, ExecutorSpecification, ExecutorStatus,
+    ExecutorStoppedParams, HeartBeatParams,
 };
-use ballista_core::serde::scheduler::ExecutorSpecification;
 use ballista_core::serde::BallistaCodec;
 use ballista_core::utils::{
     create_grpc_client_connection, create_grpc_server, with_object_store_provider,
 };
 use ballista_core::BALLISTA_VERSION;
 
-use crate::executor::Executor;
+use crate::executor::{Executor, TasksDrainedFuture};
+use crate::executor_server::TERMINATING;
 use crate::flight_service::BallistaFlightService;
 use crate::metrics::LoggingMetricsCollector;
 use crate::shutdown::Shutdown;
@@ -155,12 +159,11 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
             .map(executor_registration::OptionalHost::Host),
         port: opt.port as u32,
         grpc_port: opt.grpc_port as u32,
-        specification: Some(
-            ExecutorSpecification {
-                task_slots: concurrent_tasks as u32,
-            }
-            .into(),
-        ),
+        specification: Some(ExecutorSpecification {
+            resources: vec![ExecutorResource {
+                resource: Some(Resource::TaskSlots(concurrent_tasks as u32)),
+            }],
+        }),
     };
 
     let config = with_object_store_provider(
@@ -295,6 +298,8 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
         shutdown_noti.subscribe_for_shutdown(),
     )));
 
+    let tasks_drained = TasksDrainedFuture(executor);
+
     // Concurrently run the service checking and listen for the `shutdown` signal and wait for the stop request coming.
     // The check_services runs until an error is encountered, so under normal circumstances, this `select!` statement runs
     // until the `shutdown` signal is received or a stop request is coming.
@@ -319,7 +324,41 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
         },
     };
 
+    // Set status to fenced
+    info!("setting executor to TERMINATING status");
+    TERMINATING.store(true, Ordering::Release);
+
     if notify_scheduler {
+        // Send a heartbeat to update status of executor to `Fenced`. This should signal to the
+        // scheduler to no longer scheduler tasks on this executor
+        if let Err(error) = scheduler
+            .heart_beat_from_executor(HeartBeatParams {
+                executor_id: executor_id.clone(),
+                metrics: vec![],
+                status: Some(ExecutorStatus {
+                    status: Some(Status::Terminating(String::default())),
+                }),
+                metadata: Some(ExecutorRegistration {
+                    id: executor_id.clone(),
+                    optional_host: opt
+                        .external_host
+                        .clone()
+                        .map(executor_registration::OptionalHost::Host),
+                    port: opt.port as u32,
+                    grpc_port: opt.grpc_port as u32,
+                    specification: Some(ExecutorSpecification {
+                        resources: vec![ExecutorResource {
+                            resource: Some(Resource::TaskSlots(concurrent_tasks as u32)),
+                        }],
+                    }),
+                }),
+            })
+            .await
+        {
+            error!("error sending heartbeat with fenced status: {:?}", error);
+        }
+
+        // TODO we probably don't need a separate rpc call for this....
         if let Err(error) = scheduler
             .executor_stopped(ExecutorStoppedParams {
                 executor_id,
@@ -329,6 +368,9 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
         {
             error!("ExecutorStopped grpc failed: {:?}", error);
         }
+
+        // Wait for tasks to drain
+        tasks_drained.await;
     }
 
     // Extract the `shutdown_complete` receiver and transmitter

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -330,7 +330,7 @@ pub async fn start_executor_process(opt: ExecutorProcessConfig) -> Result<()> {
 
     if notify_scheduler {
         // Send a heartbeat to update status of executor to `Fenced`. This should signal to the
-        // scheduler to no longer scheduler tasks on this executor
+        // scheduler to no longer schedule tasks on this executor
         if let Err(error) = scheduler
             .heart_beat_from_executor(HeartBeatParams {
                 executor_id: executor_id.clone(),

--- a/ballista/scheduler/scheduler_config_spec.toml
+++ b/ballista/scheduler/scheduler_config_spec.toml
@@ -141,3 +141,9 @@ name = "job_resubmit_interval_ms"
 type = "u64"
 default = "0"
 doc = "If job is not able to be scheduled on submission, wait for this interval and resubmit. Default value of 0 indicates that job shuuld not be resubmitted"
+
+[[param]]
+name = "executor_termination_grace_period"
+type = "u64"
+default = "30"
+doc = "Time in seconds an executor should be considered lost after it enters terminating status"

--- a/ballista/scheduler/src/bin/main.rs
+++ b/ballista/scheduler/src/bin/main.rs
@@ -118,6 +118,7 @@ async fn main() -> Result<()> {
         cluster_storage: ClusterStorageConfig::Memory,
         job_resubmit_interval_ms: (opt.job_resubmit_interval_ms > 0)
             .then_some(opt.job_resubmit_interval_ms),
+        executor_termination_grace_period: opt.executor_termination_grace_period,
     };
 
     let cluster = BallistaCluster::new_from_config(&config).await?;

--- a/ballista/scheduler/src/config.rs
+++ b/ballista/scheduler/src/config.rs
@@ -49,6 +49,9 @@ pub struct SchedulerConfig {
     pub job_resubmit_interval_ms: Option<u64>,
     /// Configuration for ballista cluster storage
     pub cluster_storage: ClusterStorageConfig,
+    /// Time in seconds to allow executor for graceful shutdown. Once an executor signals it has entered Terminating status
+    /// the scheduler should only consider the executor dead after this time interval has elapsed
+    pub executor_termination_grace_period: u64,
 }
 
 impl Default for SchedulerConfig {
@@ -65,6 +68,7 @@ impl Default for SchedulerConfig {
             advertise_flight_sql_endpoint: None,
             cluster_storage: ClusterStorageConfig::Memory,
             job_resubmit_interval_ms: None,
+            executor_termination_grace_period: 0,
         }
     }
 }
@@ -139,6 +143,11 @@ impl SchedulerConfig {
 
     pub fn with_job_resubmit_interval_ms(mut self, interval_ms: u64) -> Self {
         self.job_resubmit_interval_ms = Some(interval_ms);
+        self
+    }
+
+    pub fn with_remove_executor_wait_secs(mut self, value: u64) -> Self {
+        self.executor_termination_grace_period = value;
         self
     }
 }

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -85,6 +85,10 @@ impl ExecutorReservation {
 /// to be dead.
 pub const DEFAULT_EXECUTOR_TIMEOUT_SECONDS: u64 = 180;
 
+// TODO move to configuration file
+/// Interval check for expired or dead executors
+pub const EXPIRE_DEAD_EXECUTOR_INTERVAL_SECS: u64 = 15;
+
 #[derive(Clone)]
 pub(crate) struct ExecutorManager {
     // executor slot policy
@@ -140,14 +144,19 @@ impl ExecutorManager {
         tokio::task::spawn(async move {
             while let Some(heartbeat) = heartbeat_stream.next().await {
                 let executor_id = heartbeat.executor_id.clone();
-                if let Some(ExecutorStatus {
-                    status: Some(executor_status::Status::Dead(_)),
-                }) = heartbeat.status
+
+                match heartbeat
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.status.as_ref())
                 {
-                    heartbeats.remove(&executor_id);
-                    dead_executors.insert(executor_id);
-                } else {
-                    heartbeats.insert(executor_id, heartbeat);
+                    Some(executor_status::Status::Dead(_)) => {
+                        heartbeats.remove(&executor_id);
+                        dead_executors.insert(executor_id);
+                    }
+                    _ => {
+                        heartbeats.insert(executor_id, heartbeat);
+                    }
                 }
             }
         });
@@ -614,18 +623,38 @@ impl ExecutorManager {
             .iter()
             .filter_map(|pair| {
                 let (exec, heartbeat) = pair.pair();
-                (heartbeat.timestamp > last_seen_ts_threshold).then(|| exec.clone())
+
+                let active = matches!(
+                    heartbeat
+                        .status
+                        .as_ref()
+                        .and_then(|status| status.status.as_ref()),
+                    Some(executor_status::Status::Active(_))
+                );
+                let live = heartbeat.timestamp > last_seen_ts_threshold;
+
+                (active && live).then(|| exec.clone())
             })
             .collect()
     }
 
     /// Return a list of expired executors
-    pub(crate) fn get_expired_executors(&self) -> Vec<ExecutorHeartbeat> {
+    pub(crate) fn get_expired_executors(
+        &self,
+        termination_grace_period: u64,
+    ) -> Vec<ExecutorHeartbeat> {
         let now_epoch_ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards");
+        // Threshold for last heartbeat from Active executor before marking dead
         let last_seen_threshold = now_epoch_ts
             .checked_sub(Duration::from_secs(DEFAULT_EXECUTOR_TIMEOUT_SECONDS))
+            .unwrap_or_else(|| Duration::from_secs(0))
+            .as_secs();
+
+        // Threshold for last heartbeat for Fenced executor before marking dead
+        let termination_wait_threshold = now_epoch_ts
+            .checked_sub(Duration::from_secs(termination_grace_period))
             .unwrap_or_else(|| Duration::from_secs(0))
             .as_secs();
 
@@ -634,7 +663,22 @@ impl ExecutorManager {
             .iter()
             .filter_map(|pair| {
                 let (_exec, heartbeat) = pair.pair();
-                (heartbeat.timestamp <= last_seen_threshold).then(|| heartbeat.clone())
+
+                let terminating = matches!(
+                    heartbeat
+                        .status
+                        .as_ref()
+                        .and_then(|status| status.status.as_ref()),
+                    Some(executor_status::Status::Terminating(_))
+                );
+
+                let grace_period_expired =
+                    heartbeat.timestamp <= termination_wait_threshold;
+
+                let expired = heartbeat.timestamp <= last_seen_threshold;
+
+                ((terminating && grace_period_expired) || expired)
+                    .then(|| heartbeat.clone())
             })
             .collect::<Vec<_>>();
         expired_executors
@@ -656,9 +700,12 @@ mod test {
 
     use crate::config::SlotsPolicy;
 
+    use crate::scheduler_server::timestamp_secs;
     use crate::state::executor_manager::{ExecutorManager, ExecutorReservation};
     use crate::test_utils::test_cluster_context;
     use ballista_core::error::Result;
+    use ballista_core::serde::protobuf::executor_status::Status;
+    use ballista_core::serde::protobuf::{ExecutorHeartbeat, ExecutorStatus};
     use ballista_core::serde::scheduler::{
         ExecutorData, ExecutorMetadata, ExecutorSpecification,
     };
@@ -840,6 +887,56 @@ mod test {
         let reservations = executor_manager.reserve_slots(1).await?;
 
         assert_eq!(reservations.len(), 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ignore_fenced_executors() -> Result<()> {
+        test_ignore_fenced_executors_inner(SlotsPolicy::Bias).await?;
+        test_ignore_fenced_executors_inner(SlotsPolicy::RoundRobin).await?;
+        test_ignore_fenced_executors_inner(SlotsPolicy::RoundRobinLocal).await?;
+
+        Ok(())
+    }
+
+    async fn test_ignore_fenced_executors_inner(slots_policy: SlotsPolicy) -> Result<()> {
+        let cluster = test_cluster_context();
+
+        let executor_manager =
+            ExecutorManager::new(cluster.cluster_state(), slots_policy);
+
+        // Setup two executors initially
+        let executors = test_executors(2, 4);
+
+        for (executor_metadata, executor_data) in executors {
+            let _ = executor_manager
+                .register_executor(executor_metadata, executor_data, false)
+                .await?;
+        }
+
+        // Fence one of the executors
+        executor_manager
+            .save_executor_heartbeat(ExecutorHeartbeat {
+                executor_id: "executor-0".to_string(),
+                timestamp: timestamp_secs(),
+                metrics: vec![],
+                status: Some(ExecutorStatus {
+                    status: Some(Status::Terminating(String::default())),
+                }),
+            })
+            .await?;
+
+        let reservations = executor_manager.reserve_slots(8).await?;
+
+        assert_eq!(reservations.len(), 4, "Expected only four reservations");
+
+        assert!(
+            reservations
+                .iter()
+                .all(|res| res.executor_id == "executor-1"),
+            "Expected all reservations from non-fenced executor",
+        );
 
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #655 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See #655 issues description. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Add a new executor status `Terminating` to indicate that an executor has started the termination process. 
2. On receiving a `SIGTERM` the executor will immediately send a heartbeat to update it's status to `Terminating`
3. After receiving a `SIGTERM` the executor should attempt to complete any tasks currently running before terminating
4. The scheduler should consider executors in `Active` status to be live (i.e. eligible to schedule tasks on)
5. When receiving an `executor_stopped` rpc, the scheduler will wait a configurable amount of time before removing the executor. This can be set through the new `--executor-termination-grace-period` cli flag and has a default value of 30s. 
6. When periodically checking for dead executors, the scheduler should also remove any executors in `Terminating` status for longer than `executor_termination_grace_period`.

All together this tries to ensure:
1. When an executor is terminated it has a chance to finish any in-flight tasks to minimize disruption
2. The termination of an executor will be propagated to all schedulers in the cluster through the heartbeat mechanism
3. The scheduler will give the terminating executor a grace period to complete it's tasks before resetting tasks/stages and potentially recomputing results. 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

A new cli flag `--executor-termination-grace-period` for the scheduler with a default of 30 seconds. 

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
