### PR TITLE
Allow `BallistaContext::read_*` methods to read multiple paths.

### DIFF
--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -33,8 +33,8 @@ ballista = { path = "../ballista/client", version = "0.10.0", features = [
     "standalone",
 ] }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/apache/arrow-datafusion" }
-datafusion-cli = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
+datafusion-cli = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
 dirs = "4.0.0"
 env_logger = "0.10"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -33,8 +33,8 @@ ballista = { path = "../ballista/client", version = "0.10.0", features = [
     "standalone",
 ] }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = "18.0.0"
-datafusion-cli = "18.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion-cli = { git = "https://github.com/apache/arrow-datafusion" }
 dirs = "4.0.0"
 env_logger = "0.10"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.63"
 ballista-core = { path = "../core", version = "0.10.0" }
 ballista-executor = { path = "../executor", version = "0.10.0", optional = true }
 ballista-scheduler = { path = "../scheduler", version = "0.10.0", optional = true }
-datafusion = { git = "https://github.com/apache/arrow-datafusion" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -31,8 +31,8 @@ rust-version = "1.63"
 ballista-core = { path = "../core", version = "0.10.0" }
 ballista-executor = { path = "../executor", version = "0.10.0", optional = true }
 ballista-scheduler = { path = "../scheduler", version = "0.10.0", optional = true }
-datafusion = "18.0.0"
-datafusion-proto = "18.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion" }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/client/src/context.rs
+++ b/ballista/client/src/context.rs
@@ -18,6 +18,7 @@
 //! Distributed execution context.
 
 use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::execution::context::DataFilePaths;
 use log::info;
 use parking_lot::Mutex;
 use sqlparser::ast::Statement;
@@ -39,7 +40,7 @@ use datafusion::datasource::{source_as_provider, TableProvider};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::{CreateExternalTable, LogicalPlan, TableScan};
 use datafusion::prelude::{
-    AvroReadOptions, CsvReadOptions, ParquetReadOptions, SessionConfig, SessionContext,
+    AvroReadOptions, CsvReadOptions, ParquetReadOptions, SessionConfig, SessionContext, NdJsonReadOptions,
 };
 use datafusion::sql::parser::{DFParser, Statement as DFStatement};
 
@@ -207,36 +208,47 @@ impl BallistaContext {
         })
     }
 
+    /// Create a DataFrame representing an Json table scan
+    /// TODO fetch schema from scheduler instead of resolving locally
+    pub async fn read_json<P: DataFilePaths>(
+        &self,
+        paths: P,
+        options: NdJsonReadOptions<'_>,
+    ) -> Result<DataFrame> {
+        let df = self.context.read_json(paths, options).await?;
+        Ok(df)
+    }
+
     /// Create a DataFrame representing an Avro table scan
     /// TODO fetch schema from scheduler instead of resolving locally
-    pub async fn read_avro(
+    pub async fn read_avro<P: DataFilePaths>(
         &self,
-        path: &str,
+        paths: P,
         options: AvroReadOptions<'_>,
     ) -> Result<DataFrame> {
-        let df = self.context.read_avro(path, options).await?;
+        let df = self.context.read_avro(paths, options).await?;
         Ok(df)
     }
 
     /// Create a DataFrame representing a Parquet table scan
     /// TODO fetch schema from scheduler instead of resolving locally
-    pub async fn read_parquet(
+    pub async fn read_parquet<P: DataFilePaths>(
         &self,
-        path: &str,
+        paths: P,
         options: ParquetReadOptions<'_>,
     ) -> Result<DataFrame> {
-        let df = self.context.read_parquet(path, options).await?;
+        let df = self.context.read_parquet(paths, options).await?;
         Ok(df)
     }
 
     /// Create a DataFrame representing a CSV table scan
     /// TODO fetch schema from scheduler instead of resolving locally
-    pub async fn read_csv(
+    pub async fn read_csv<P: DataFilePaths>(
         &self,
-        path: &str,
+        paths: P,
         options: CsvReadOptions<'_>,
     ) -> Result<DataFrame> {
-        let df = self.context.read_csv(path, options).await?;
+        let df = self.context.read_csv(paths, options).await?;
         Ok(df)
     }
 

--- a/ballista/client/src/context.rs
+++ b/ballista/client/src/context.rs
@@ -40,7 +40,8 @@ use datafusion::datasource::{source_as_provider, TableProvider};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::{CreateExternalTable, LogicalPlan, TableScan};
 use datafusion::prelude::{
-    AvroReadOptions, CsvReadOptions, ParquetReadOptions, SessionConfig, SessionContext, NdJsonReadOptions,
+    AvroReadOptions, CsvReadOptions, NdJsonReadOptions, ParquetReadOptions,
+    SessionConfig, SessionContext,
 };
 use datafusion::sql::parser::{DFParser, Statement as DFStatement};
 

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -50,9 +50,9 @@ arrow-flight = { version = "32.0.0", features = ["flight-sql-experimental"] }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = "18.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion" }
 datafusion-objectstore-hdfs = { version = "0.1.1", default-features = false, optional = true }
-datafusion-proto = "18.0.0"
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion" }
 futures = "0.3"
 hashbrown = "0.13"
 

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -50,9 +50,9 @@ arrow-flight = { version = "32.0.0", features = ["flight-sql-experimental"] }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
 datafusion-objectstore-hdfs = { version = "0.1.1", default-features = false, optional = true }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
 futures = "0.3"
 hashbrown = "0.13"
 

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -45,8 +45,8 @@ ballista-core = { path = "../core", version = "0.10.0" }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
 dashmap = "5.4.0"
-datafusion = "18.0.0"
-datafusion-proto = "18.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion" }
 futures = "0.3"
 hyper = "0.14.4"
 log = "0.4"

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -45,8 +45,8 @@ ballista-core = { path = "../core", version = "0.10.0" }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
 dashmap = "5.4.0"
-datafusion = { git = "https://github.com/apache/arrow-datafusion" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
 futures = "0.3"
 hyper = "0.14.4"
 log = "0.4"

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -51,8 +51,8 @@ base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
 dashmap = "5.4.0"
-datafusion = { git = "https://github.com/apache/arrow-datafusion" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
 etcd-client = { version = "0.10", optional = true }
 flatbuffers = { version = "22.9.29" }
 futures = "0.3"

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -51,8 +51,8 @@ base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
 dashmap = "5.4.0"
-datafusion = "18.0.0"
-datafusion-proto = "18.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion" }
 etcd-client = { version = "0.10", optional = true }
 flatbuffers = { version = "22.9.29" }
 futures = "0.3"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -34,8 +34,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "0.10.0" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
 env_logger = "0.10"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -34,8 +34,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "0.10.0" }
-datafusion = "18.0.0"
-datafusion-proto = "18.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion" }
 env_logger = "0.10"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "0.10.0" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "cfbb14d" }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "0.10.0" }
-datafusion = "18.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion" }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11"


### PR DESCRIPTION
# Which issue does this PR close?
Closes #584. Closes #587.

 # Rationale for this change
Add the ability to read multiple files using `read_*` methods.

# What changes are included in this PR?
1. Added `read_json` method
2. Modified function signature to take any argument implementing `DataFilePaths` trait.

# Are there any user-facing changes?
Yes, they will be able to use `read_*` methods as follows: `read_csv(vec!["", ""])`