### PR TITLE
Allow accessing s3 locations in client mode

### DIFF
--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -41,7 +41,7 @@ anyhow = "1"
 arrow = { version = "33.0.0" }
 arrow-flight = { version = "33.0.0" }
 async-trait = "0.1.41"
-ballista-core = { path = "../core", version = "0.11.0" }
+ballista-core = { path = "../core", version = "0.11.0" , features = ["s3"] }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
 dashmap = "5.4.0"

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -46,7 +46,7 @@ anyhow = "1"
 arrow-flight = { version = "33.0.0", features = ["flight-sql-experimental"] }
 async-recursion = "1.0.0"
 async-trait = "0.1.41"
-ballista-core = { path = "../core", version = "0.11.0" }
+ballista-core = { path = "../core", version = "0.11.0" , features = ["s3"] }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
@@ -87,7 +87,7 @@ uuid = { version = "1.0", features = ["v4"] }
 warp = "0.3"
 
 [dev-dependencies]
-ballista-core = { path = "../core", version = "0.11.0" }
+ballista-core = { path = "../core", version = "0.11.0"  , features = ["s3"] }
 
 [build-dependencies]
 configure_me_codegen = "=0.4.0"


### PR DESCRIPTION
# Which issue does this PR close?
Partially addressess #6 .

Closes #.

 # Rationale for this change
Was able to read data from S3 in standalone mode but in client mode, it gives the error `DataFusion error: Execution("No object store available for s3://path/to/folder/")`

# What changes are included in this PR?
Added `S3` feature to `Scheduler` and `Executor`. Not having this feature in either will again give the above error.

# Are there any user-facing changes?
User will be access S3 paths in client mode.