### PR TITLE
Update link to scheduler proto file in dev docs

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -51,7 +51,7 @@ processes.
 ## Scheduler Process
 
 The scheduler process implements a gRPC interface (defined in
-[ballista.proto](../core/proto/ballista.proto)). The interface provides the following methods:
+[ballista.proto](../../ballista/core/proto/ballista.proto)). The interface provides the following methods:
 
 | Method               | Description                                                          |
 | -------------------- | -------------------------------------------------------------------- |


### PR DESCRIPTION
The link to the protobuffer file was outdated, this links to the correct file

# What changes are included in this PR?

This updates the link to the scheduler protobuf file

# Are there any user-facing changes?
no