### PR TITLE
Issue 717 use nvm in docker build

### DIFF
--- a/dev/docker/ballista-builder.Dockerfile
+++ b/dev/docker/ballista-builder.Dockerfile
@@ -24,16 +24,30 @@ ENV RUST_BACKTRACE=full
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get -y install libssl-dev openssl zlib1g zlib1g-dev libpq-dev cmake protobuf-compiler netcat curl unzip \
-    nodejs npm && \
-    npm install -g yarn
+    apt-get -y install libssl-dev openssl zlib1g zlib1g-dev libpq-dev cmake protobuf-compiler netcat curl unzip
+
+# install nvm
+ENV NODE_VER=18.9.0
+ENV NVM_DIR /usr/local/nvm
+RUN mkdir $NVM_DIR
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+RUN chmod +x $NVM_DIR/nvm.sh
+
+# Install node using nvm
+RUN . $NVM_DIR/nvm.sh && nvm install $NODE_VER && nvm alias default $NODE_VER && nvm use default
+
+ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VER/lib/node_modules
+ENV PATH      $NVM_DIR/versions/node/v$NODE_VER/bin:$PATH
+
+# install yarn
+RUN npm install -g yarn
 
 # create build user with same UID as 
 RUN adduser -q -u $EXT_UID builder --home /home/builder && \
     mkdir -p /home/builder/workspace
 USER builder
 
-ENV NODE_VER=18.9.0
 ENV HOME=/home/builder
 ENV PATH=$HOME/.cargo/bin:$PATH
 

--- a/dev/docker/ballista-builder.Dockerfile
+++ b/dev/docker/ballista-builder.Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     apt-get -y install libssl-dev openssl zlib1g zlib1g-dev libpq-dev cmake protobuf-compiler netcat curl unzip
 
 # install nvm
-ENV NODE_VER=18.9.0
+ENV NODE_VER=16.9.1
 ENV NVM_DIR /usr/local/nvm
 RUN mkdir $NVM_DIR
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #717.

 # Rationale for this change
The current build for the `main` branch is broken, as reported in the issue #717. This change aims to make it working again.

# What changes are included in this PR?
- Changes to the builder Dockerfile to use the NVM to install the appropriate node version.
- Sets node version to v16.9.1

# Are there any user-facing changes?
No, but it may be useful to update the documentation to showcase that it's now possible to build from the `main` branch.