### PR TITLE
Fix parameter '--config-backend' to '--cluster-backend'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     build:
       dockerfile: dev/docker/ballista-scheduler.Dockerfile
       context: .
-    command: "--config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0"
+    command: "--cluster-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0"
     ports:
       - "80:80"
       - "50050:50050"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #719 .

 # Rationale for this change
It seems the parameter `config-backend` passed in `docker-compose.yml` is wrong and is now called `cluster-backend`.

# What changes are included in this PR?
The default parameter for the scheduler is now `--cluster-backend etcd`.

# Are there any user-facing changes?
No, except that now the `docker-compose.yml` should work with no changes from end users.
