### PR TITLE
[fea] Avoid multithreaded  write lock conflicts in event queue.

### DIFF
--- a/ballista/scheduler/src/scheduler_server/event.rs
+++ b/ballista/scheduler/src/scheduler_server/event.rs
@@ -22,6 +22,7 @@ use datafusion::logical_expr::LogicalPlan;
 
 use crate::state::execution_graph::RunningTaskInfo;
 use ballista_core::serde::protobuf::TaskStatus;
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 use std::sync::Arc;
 
@@ -36,9 +37,12 @@ pub enum QueryStageSchedulerEvent {
     },
     JobSubmitted {
         job_id: String,
+        job_name: String,
+        session_id: String,
         queued_at: u64,
         submitted_at: u64,
         resubmit: bool,
+        plan: Arc<dyn ExecutionPlan>,
     },
     // For a job which failed during planning
     JobPlanningFailed {
@@ -76,8 +80,10 @@ impl Debug for QueryStageSchedulerEvent {
             } => {
                 write!(f, "JobQueued : job_id={job_id}, job_name={job_name}.")
             }
-            QueryStageSchedulerEvent::JobSubmitted { job_id, .. } => {
-                write!(f, "JobSubmitted : job_id={job_id}.")
+            QueryStageSchedulerEvent::JobSubmitted {
+                job_id, resubmit, ..
+            } => {
+                write!(f, "JobSubmitted : job_id={job_id}, resubmit={resubmit}.")
             }
             QueryStageSchedulerEvent::JobPlanningFailed {
                 job_id,

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -440,12 +440,19 @@ mod test {
             .queue_job(job_id, "", timestamp_millis())
             .await?;
 
-        // Submit job
-        scheduler
+        // Plan job
+        let plan = scheduler
             .state
-            .submit_job(job_id, "", ctx, &plan, 0)
+            .plan_job(job_id, ctx.clone(), &plan)
             .await
             .expect("submitting plan");
+
+        //Submit job plan
+        scheduler
+            .state
+            .task_manager
+            .submit_job(job_id, "", &ctx.session_id(), plan, 0)
+            .await?;
 
         // Refresh the ExecutionGraph
         while let Some(graph) = scheduler


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #753.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

After fix concurrency visit lock  before four long running event reduce to 200~500 micro seconds cost. 

```
2023-04-17T05:36:45.695838Z  WARN tokio-runtime-worker ThreadId(16) ballista_scheduler::scheduler_server::query_stage_scheduler: [METRICS] JobUpdated : job_id=jr3EVUI. events cost 553 us!
```
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
