### PR TITLE
Fix plan metrics length and stage metrics length not match

### DIFF
--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -116,6 +116,6 @@ impl QueryStageExecutor for DefaultQueryStageExec {
     }
 
     fn collect_plan_metrics(&self) -> Vec<MetricsSet> {
-        utils::collect_plan_metrics(self.shuffle_writer.children()[0].as_ref())
+        utils::collect_plan_metrics(&self.shuffle_writer)
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #763.

We got lots of error log as follows due to mismatch of the length between plan metrics and stage metrics:
`2023-04-27T07:08:05.745787Z ERROR tokio-runtime-worker ThreadId(07) ballista_scheduler::display: Fail to combine stage metrics to plan for stage [5H4NLbc/3],  plan metrics array size 5 does not equal to the stage metrics array size 4`

The metrics length of stage is always one less than the one of plan.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It's caused by #687.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
