### PR TITLE
Make last_seen_ts_threshold for getting alive executor at the scheduler side larger than the heartbeat time interval

### DIFF
--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -61,7 +61,7 @@ use std::io::{BufWriter, Write};
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{fs::File, pin::Pin};
 use tonic::codegen::StdError;
 use tonic::transport::{Channel, Error, Server};
@@ -471,4 +471,15 @@ pub fn collect_plan_metrics(plan: &dyn ExecutionPlan) -> Vec<MetricsSet> {
             .for_each(|e| metrics_array.push(e))
     });
     metrics_array
+}
+
+/// Given an interval in seconds, get the time in seconds before now
+pub fn get_time_before(interval_seconds: u64) -> u64 {
+    let now_epoch_ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+    now_epoch_ts
+        .checked_sub(Duration::from_secs(interval_seconds))
+        .unwrap_or_else(|| Duration::from_secs(0))
+        .as_secs()
 }

--- a/ballista/executor/executor_config_spec.toml
+++ b/ballista/executor/executor_config_spec.toml
@@ -131,3 +131,9 @@ name = "grpc_server_max_decoding_message_size"
 type = "u32"
 default = "16777216"
 doc = "The maximum size of a decoded message at the grpc server side. Default: 16MB"
+
+[[param]]
+name = "executor_heartbeat_interval_seconds"
+type = "u64"
+doc = "The heartbeat interval in seconds to the scheduler for push-based task scheduling"
+default = "60"

--- a/ballista/executor/src/bin/main.rs
+++ b/ballista/executor/src/bin/main.rs
@@ -79,6 +79,7 @@ async fn main() -> Result<()> {
         job_data_ttl_seconds: opt.job_data_ttl_seconds,
         job_data_clean_up_interval_seconds: opt.job_data_clean_up_interval_seconds,
         grpc_server_max_decoding_message_size: opt.grpc_server_max_decoding_message_size,
+        executor_heartbeat_interval_seconds: opt.executor_heartbeat_interval_seconds,
         execution_engine: None,
     };
 

--- a/ballista/scheduler/scheduler_config_spec.toml
+++ b/ballista/scheduler/scheduler_config_spec.toml
@@ -158,3 +158,15 @@ name = "grpc_server_max_decoding_message_size"
 type = "u32"
 default = "16777216"
 doc = "The maximum size of a decoded message at the grpc server side. Default: 16MB"
+
+[[param]]
+name = "executor_timeout_seconds"
+type = "u64"
+doc = "The executor timeout in seconds. It should be longer than executor's heartbeat intervals. Only after missing two or tree consecutive heartbeats from a executor, the executor is mark to be dead"
+default = "180"
+
+[[param]]
+name = "expire_dead_executor_interval_seconds"
+type = "u64"
+doc = "The interval to check expired or dead executors"
+default = "15"

--- a/ballista/scheduler/src/bin/main.rs
+++ b/ballista/scheduler/src/bin/main.rs
@@ -17,6 +17,7 @@
 
 //! Ballista Rust scheduler binary.
 
+use std::sync::Arc;
 use std::{env, io};
 
 use anyhow::Result;
@@ -139,10 +140,12 @@ async fn main() -> Result<()> {
         scheduler_event_expected_processing_duration: opt
             .scheduler_event_expected_processing_duration,
         grpc_server_max_decoding_message_size: opt.grpc_server_max_decoding_message_size,
+        executor_timeout_seconds: opt.executor_timeout_seconds,
+        expire_dead_executor_interval_seconds: opt.expire_dead_executor_interval_seconds,
     };
 
     let cluster = BallistaCluster::new_from_config(&config).await?;
 
-    start_server(cluster, addr, config).await?;
+    start_server(cluster, addr, Arc::new(config)).await?;
     Ok(())
 }

--- a/ballista/scheduler/src/config.rs
+++ b/ballista/scheduler/src/config.rs
@@ -56,6 +56,10 @@ pub struct SchedulerConfig {
     pub scheduler_event_expected_processing_duration: u64,
     /// The maximum size of a decoded message at the grpc server side.
     pub grpc_server_max_decoding_message_size: u32,
+    /// The executor timeout in seconds. It should be longer than executor's heartbeat intervals.
+    pub executor_timeout_seconds: u64,
+    /// The interval to check expired or dead executors
+    pub expire_dead_executor_interval_seconds: u64,
 }
 
 impl Default for SchedulerConfig {
@@ -75,6 +79,8 @@ impl Default for SchedulerConfig {
             executor_termination_grace_period: 0,
             scheduler_event_expected_processing_duration: 0,
             grpc_server_max_decoding_message_size: 16777216,
+            executor_timeout_seconds: 180,
+            expire_dead_executor_interval_seconds: 15,
         }
     }
 }

--- a/ballista/scheduler/src/scheduler_process.rs
+++ b/ballista/scheduler/src/scheduler_process.rs
@@ -23,6 +23,7 @@ use hyper::{server::conn::AddrStream, service::make_service_fn, Server};
 use log::info;
 use std::convert::Infallible;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tonic::transport::server::Connected;
 use tower::Service;
 
@@ -44,7 +45,7 @@ use crate::scheduler_server::SchedulerServer;
 pub async fn start_server(
     cluster: BallistaCluster,
     addr: SocketAddr,
-    config: SchedulerConfig,
+    config: Arc<SchedulerConfig>,
 ) -> Result<()> {
     info!(
         "Ballista v{} Scheduler listening on {:?}",

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -29,6 +29,7 @@ use datafusion_proto::protobuf::LogicalPlanNode;
 use datafusion_proto::protobuf::PhysicalPlanNode;
 use log::info;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::net::TcpListener;
 
 pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
@@ -46,7 +47,7 @@ pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
             "localhost:50050".to_owned(),
             cluster,
             BallistaCodec::default(),
-            SchedulerConfig::default(),
+            Arc::new(SchedulerConfig::default()),
             metrics_collector,
         );
 

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -92,33 +92,20 @@ pub struct SchedulerState<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPl
     pub task_manager: TaskManager<T, U>,
     pub session_manager: SessionManager,
     pub codec: BallistaCodec<T, U>,
-    pub config: SchedulerConfig,
+    pub config: Arc<SchedulerConfig>,
 }
 
 impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T, U> {
-    #[cfg(test)]
-    pub fn new_with_default_scheduler_name(
-        cluster: BallistaCluster,
-        codec: BallistaCodec<T, U>,
-    ) -> Self {
-        SchedulerState::new(
-            cluster,
-            codec,
-            "localhost:50050".to_owned(),
-            SchedulerConfig::default(),
-        )
-    }
-
     pub fn new(
         cluster: BallistaCluster,
         codec: BallistaCodec<T, U>,
         scheduler_name: String,
-        config: SchedulerConfig,
+        config: Arc<SchedulerConfig>,
     ) -> Self {
         Self {
             executor_manager: ExecutorManager::new(
                 cluster.cluster_state(),
-                config.task_distribution,
+                config.clone(),
             ),
             task_manager: TaskManager::new(
                 cluster.job_state(),
@@ -131,18 +118,27 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         }
     }
 
+    #[cfg(test)]
+    pub fn new_with_default_scheduler_name(
+        cluster: BallistaCluster,
+        codec: BallistaCodec<T, U>,
+    ) -> Self {
+        let config = Arc::new(SchedulerConfig::default());
+        SchedulerState::new(cluster, codec, "localhost:50050".to_owned(), config)
+    }
+
     #[allow(dead_code)]
     pub(crate) fn new_with_task_launcher(
         cluster: BallistaCluster,
         codec: BallistaCodec<T, U>,
         scheduler_name: String,
-        config: SchedulerConfig,
+        config: Arc<SchedulerConfig>,
         dispatcher: Arc<dyn TaskLauncher>,
     ) -> Self {
         Self {
             executor_manager: ExecutorManager::new(
                 cluster.cluster_state(),
-                config.task_distribution,
+                config.clone(),
             ),
             task_manager: TaskManager::with_launcher(
                 cluster.job_state(),
@@ -470,12 +466,13 @@ mod test {
             .set(BALLISTA_DEFAULT_SHUFFLE_PARTITIONS, "4")
             .build()?;
 
+        let scheduler_config = SchedulerConfig::default();
         let state: Arc<SchedulerState<LogicalPlanNode, PhysicalPlanNode>> =
             Arc::new(SchedulerState::new_with_task_launcher(
                 test_cluster_context(),
                 BallistaCodec::default(),
                 TEST_SCHEDULER_NAME.into(),
-                SchedulerConfig::default(),
+                Arc::new(scheduler_config),
                 Arc::new(BlackholeTaskLauncher::default()),
             ));
 
@@ -570,12 +567,13 @@ mod test {
             .set(BALLISTA_DEFAULT_SHUFFLE_PARTITIONS, "4")
             .build()?;
 
+        let scheduler_config = SchedulerConfig::default();
         let state: Arc<SchedulerState<LogicalPlanNode, PhysicalPlanNode>> =
             Arc::new(SchedulerState::new_with_task_launcher(
                 test_cluster_context(),
                 BallistaCodec::default(),
                 TEST_SCHEDULER_NAME.into(),
-                SchedulerConfig::default(),
+                Arc::new(scheduler_config),
                 Arc::new(BlackholeTaskLauncher::default()),
             ));
 

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -425,7 +425,7 @@ impl SchedulerTest {
                 "localhost:50050".to_owned(),
                 cluster,
                 BallistaCodec::default(),
-                config,
+                Arc::new(config),
                 metrics_collector,
                 Arc::new(launcher),
             );


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #785.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Make hard coded settings configurable, like **DEFAULT_EXECUTOR_TIMEOUT_SECONDS**, **EXPIRE_DEAD_EXECUTOR_INTERVAL_SECS**.
- Make several structs for scheduler have the **SchedulerConfig** property and remove detailed settings, like **ExecutorManager**, **QueryStageScheduler**, etc.
- Use the **executor_timeout_seconds** for alive executor detection. It's larger than the **executor_heartbeat_interval_seconds**.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
