### PR TITLE
Reduce the number of calls to `create_logical_plan`

### DIFF
--- a/ballista/client/src/context.rs
+++ b/ballista/client/src/context.rs
@@ -455,7 +455,7 @@ impl BallistaContext {
                     ))),
                 }
             }
-            _ => ctx.sql(sql).await,
+            _ => ctx.execute_logical_plan(plan).await,
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

None

 # Rationale for this change
There is a duplicate invocation of `create_logical_plan` within `ctx.sql(sql)`.
Since we already have a logical plan at hand, perhaps we can execute it directly.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No
