### PR TITLE
refactor: port get_scan_files to Ballista

### DIFF
--- a/ballista/scheduler/src/cluster/kv.rs
+++ b/ballista/scheduler/src/cluster/kv.rs
@@ -17,7 +17,7 @@
 
 use crate::cluster::storage::{KeyValueStore, Keyspace, Lock, Operation, WatchEvent};
 use crate::cluster::{
-    bind_task_bias, bind_task_consistent_hash, bind_task_round_robin,
+    bind_task_bias, bind_task_consistent_hash, bind_task_round_robin, get_scan_files,
     is_skip_consistent_hash, BoundTask, ClusterState, ExecutorHeartbeatStream,
     ExecutorSlot, JobState, JobStateEvent, JobStateEventStream, JobStatus,
     TaskDistributionPolicy, TopologyNode,
@@ -39,7 +39,6 @@ use ballista_core::serde::protobuf::{
 use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
 use ballista_core::serde::BallistaCodec;
 use dashmap::DashMap;
-use datafusion::datasource::physical_plan::get_scan_files;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 use datafusion_proto::logical_plan::AsLogicalPlan;

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::cluster::{
-    bind_task_bias, bind_task_consistent_hash, bind_task_round_robin,
+    bind_task_bias, bind_task_consistent_hash, bind_task_round_robin, get_scan_files,
     is_skip_consistent_hash, BoundTask, ClusterState, ExecutorSlot, JobState,
     JobStateEvent, JobStateEventStream, JobStatus, TaskDistributionPolicy, TopologyNode,
 };
@@ -42,7 +42,6 @@ use std::collections::{HashMap, HashSet};
 use std::ops::DerefMut;
 
 use ballista_core::consistent_hash::node::Node;
-use datafusion::datasource::physical_plan::get_scan_files;
 use datafusion::physical_plan::ExecutionPlan;
 use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard};


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-datafusion/issues/7357





 # Rationale for this change

We are sorting out how to split up DataFusion into smaller modules, and we hit https://github.com/apache/arrow-datafusion/issues/7357

There is a tension between knowing about datasources and separating out physical plan and datasources (see commentary on https://github.com/apache/arrow-datafusion/issues/7357 and linked PRs). 

We thus propose to move this API upstream into Ballista. See  https://github.com/apache/arrow-datafusion/pull/7487 

# What changes are included in this PR?
1. Move this API upstream into Ballista:  https://github.com/apache/arrow-datafusion/pull/7487 

# Are there any user-facing changes?
No