### PR TITLE
Set max message size to 16MB in gRPC clients

### DIFF
--- a/ballista/client/src/context.rs
+++ b/ballista/client/src/context.rs
@@ -100,7 +100,9 @@ impl BallistaContext {
         let connection = create_grpc_client_connection(scheduler_url.clone())
             .await
             .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-        let mut scheduler = SchedulerGrpcClient::new(connection);
+        let mut scheduler = SchedulerGrpcClient::new(connection)
+            .max_encoding_message_size(16 * 1024 * 1024)
+            .max_decoding_message_size(16 * 1024 * 1024);
 
         let remote_session_id = scheduler
             .create_session(CreateSessionParams {

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -229,7 +229,9 @@ async fn execute_query(
         .await
         .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
 
-    let mut scheduler = SchedulerGrpcClient::new(connection);
+    let mut scheduler = SchedulerGrpcClient::new(connection)
+        .max_encoding_message_size(16 * 1024 * 1024)
+        .max_decoding_message_size(16 * 1024 * 1024);
 
     let query_result = scheduler
         .execute_query(query)

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -284,7 +284,9 @@ pub async fn start_executor_process(opt: Arc<ExecutorProcessConfig>) -> Result<(
         }
     }?;
 
-    let mut scheduler = SchedulerGrpcClient::new(connection);
+    let mut scheduler = SchedulerGrpcClient::new(connection)
+        .max_encoding_message_size(16 * 1024 * 1024)
+        .max_decoding_message_size(16 * 1024 * 1024);
 
     let default_codec: BallistaCodec<LogicalPlanNode, PhysicalPlanNode> =
         BallistaCodec::default();

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -237,7 +237,9 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
         } else {
             let scheduler_url = format!("http://{scheduler_id}");
             let connection = create_grpc_client_connection(scheduler_url).await?;
-            let scheduler = SchedulerGrpcClient::new(connection);
+            let scheduler = SchedulerGrpcClient::new(connection)
+                .max_encoding_message_size(16 * 1024 * 1024)
+                .max_decoding_message_size(16 * 1024 * 1024);
 
             {
                 self.schedulers


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-ballista/issues/773

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This enables me to run TPC-H again.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Explicitly set max encoding/decoding message sizes in gRPC clients to match the default for the servers. It would be better to make this configurable, so I filed a follow-on issue for that (https://github.com/apache/arrow-ballista/issues/930).

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
