### PR TITLE
Use StreamWriter instead of FileWriter

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion::arrow::ipc::reader::StreamReader;
 use async_trait::async_trait;
+use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::common::stats::Precision;
 use std::any::Any;
 use std::collections::HashMap;
@@ -33,7 +33,6 @@ use crate::serde::scheduler::{PartitionLocation, PartitionStats};
 
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::error::ArrowError;
-use datafusion::arrow::ipc::reader::FileReader;
 use datafusion::arrow::record_batch::RecordBatch;
 
 use datafusion::error::Result;
@@ -440,7 +439,6 @@ mod tests {
     use crate::utils;
     use datafusion::arrow::array::{Int32Array, StringArray, UInt32Array};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::arrow::ipc::writer::FileWriter;
     use datafusion::arrow::ipc::writer::StreamWriter;
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::common::DataFusionError;

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -15,12 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use datafusion::arrow::ipc::reader::StreamReader;
 use async_trait::async_trait;
 use datafusion::common::stats::Precision;
 use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fs::File;
+use std::io::BufReader;
 use std::pin::Pin;
 use std::result;
 use std::sync::Arc;
@@ -209,11 +211,11 @@ fn stats_for_partitions(
 }
 
 struct LocalShuffleStream {
-    reader: FileReader<File>,
+    reader: StreamReader<BufReader<File>>,
 }
 
 impl LocalShuffleStream {
-    pub fn new(reader: FileReader<File>) -> Self {
+    pub fn new(reader: StreamReader<BufReader<File>>) -> Self {
         LocalShuffleStream { reader }
     }
 }
@@ -412,13 +414,14 @@ async fn fetch_partition_local(
 
 fn fetch_partition_local_inner(
     path: &str,
-) -> result::Result<FileReader<File>, BallistaError> {
+) -> result::Result<StreamReader<BufReader<File>>, BallistaError> {
     let file = File::open(path).map_err(|e| {
         BallistaError::General(format!("Failed to open partition file at {path}: {e:?}"))
     })?;
-    FileReader::try_new(file, None).map_err(|e| {
+    let reader = StreamReader::try_new(file, None).map_err(|e| {
         BallistaError::General(format!("Failed to new arrow FileReader at {path}: {e:?}"))
-    })
+    })?;
+    Ok(reader)
 }
 
 async fn fetch_partition_object_store(
@@ -438,6 +441,7 @@ mod tests {
     use datafusion::arrow::array::{Int32Array, StringArray, UInt32Array};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::ipc::writer::FileWriter;
+    use datafusion::arrow::ipc::writer::StreamWriter;
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::common::DataFusionError;
     use datafusion::physical_expr::expressions::Column;
@@ -627,7 +631,7 @@ mod tests {
         let tmp_dir = tempdir().unwrap();
         let file_path = tmp_dir.path().join("shuffle_data");
         let file = File::create(&file_path).unwrap();
-        let mut writer = FileWriter::try_new(file, &schema).unwrap();
+        let mut writer = StreamWriter::try_new(file, &schema).unwrap();
         writer.write(&batch).unwrap();
         writer.finish().unwrap();
 

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -24,6 +24,7 @@ use datafusion::arrow::ipc::writer::IpcWriteOptions;
 use datafusion::arrow::ipc::CompressionType;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 
+use datafusion::arrow::ipc::writer::StreamWriter;
 use std::any::Any;
 use std::fs;
 use std::fs::File;
@@ -32,7 +33,6 @@ use std::iter::Iterator;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
-use datafusion::arrow::ipc::writer::StreamWriter;
 
 use crate::utils;
 
@@ -45,7 +45,6 @@ use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::physical_plan::common::IPCWriter;
 use datafusion::physical_plan::memory::MemoryStream;
 use datafusion::physical_plan::metrics::{
     self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
@@ -295,7 +294,7 @@ impl ShuffleWriterExec {
                                 debug!(
                                     "Finished writing shuffle partition {} at {:?}. Batches: {}. Rows: {}. Bytes: {}.",
                                     i,
-                                    w.path(),
+                                    w.path,
                                     w.num_batches,
                                     w.num_rows,
                                     num_bytes
@@ -303,7 +302,7 @@ impl ShuffleWriterExec {
 
                                 part_locs.push(ShuffleWritePartition {
                                     partition_id: i as u64,
-                                    path: w.path().to_string_lossy().to_string(),
+                                    path: w.path.to_string_lossy().to_string(),
                                     num_batches: w.num_batches as u64,
                                     num_rows: w.num_rows as u64,
                                     num_bytes,

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -26,8 +26,9 @@ use crate::serde::scheduler::PartitionStats;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::ipc::writer::IpcWriteOptions;
+use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion::arrow::ipc::CompressionType;
-use datafusion::arrow::{ipc::writer::FileWriter, record_batch::RecordBatch};
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::physical_plan::{CsvExec, ParquetExec};
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::{
@@ -58,7 +59,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{fs::File, pin::Pin};
 use tonic::codegen::StdError;
 use tonic::transport::{Channel, Error, Server};
-use datafusion::arrow::ipc::writer::StreamWriter;
 
 /// Default session builder using the provided configuration
 pub fn default_session_builder(config: SessionConfig) -> SessionState {

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -58,6 +58,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{fs::File, pin::Pin};
 use tonic::codegen::StdError;
 use tonic::transport::{Channel, Error, Server};
+use datafusion::arrow::ipc::writer::StreamWriter;
 
 /// Default session builder using the provided configuration
 pub fn default_session_builder(config: SessionConfig) -> SessionState {
@@ -89,7 +90,7 @@ pub async fn write_stream_to_disk(
         .try_with_compression(Some(CompressionType::LZ4_FRAME))?;
 
     let mut writer =
-        FileWriter::try_new_with_options(file, stream.schema().as_ref(), options)?;
+        StreamWriter::try_new_with_options(file, stream.schema().as_ref(), options)?;
 
     while let Some(result) = stream.next().await {
         let batch = result?;

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -17,8 +17,8 @@
 
 //! Implementation of the Apache Arrow Flight protocol that wraps an executor.
 
-use std::convert::TryFrom;
 use arrow::ipc::reader::StreamReader;
+use std::convert::TryFrom;
 use std::fs::File;
 use std::pin::Pin;
 
@@ -35,9 +35,7 @@ use arrow_flight::{
     FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse,
     PutResult, SchemaResult, Ticket,
 };
-use datafusion::arrow::{
-    error::ArrowError, ipc::reader::FileReader, record_batch::RecordBatch,
-};
+use datafusion::arrow::{error::ArrowError, record_batch::RecordBatch};
 use futures::{Stream, StreamExt, TryStreamExt};
 use log::{debug, info};
 use std::io::{Read, Seek};

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -18,6 +18,7 @@
 //! Implementation of the Apache Arrow Flight protocol that wraps an executor.
 
 use std::convert::TryFrom;
+use arrow::ipc::reader::StreamReader;
 use std::fs::File;
 use std::pin::Pin;
 
@@ -97,7 +98,7 @@ impl FlightService for BallistaFlightService {
                     })
                     .map_err(|e| from_ballista_err(&e))?;
                 let reader =
-                    FileReader::try_new(file, None).map_err(|e| from_arrow_err(&e))?;
+                    StreamReader::try_new(file, None).map_err(|e| from_arrow_err(&e))?;
 
                 let (tx, rx) = channel(2);
                 let schema = reader.schema();
@@ -207,7 +208,7 @@ impl FlightService for BallistaFlightService {
 }
 
 fn read_partition<T>(
-    reader: FileReader<T>,
+    reader: StreamReader<std::io::BufReader<T>>,
     tx: Sender<Result<RecordBatch, FlightError>>,
 ) -> Result<(), FlightError>
 where


### PR DESCRIPTION
# Which issue does this PR close?

Closes #942.

# Rationale for this change

Described in issue, but also dictionaries don't work properly when using FileWriter (there are duplicate dictionary ID errors). 

# What changes are included in this PR?

Switch from FileWriter to StreamWriter

# Are there any user-facing changes?

Dictionaries should work.