### PR TITLE
Remove some TODO comments related to context fetching schemas from scheduler

### DIFF
--- a/ballista/client/src/context.rs
+++ b/ballista/client/src/context.rs
@@ -210,7 +210,6 @@ impl BallistaContext {
     }
 
     /// Create a DataFrame representing an Json table scan
-    /// TODO fetch schema from scheduler instead of resolving locally
     pub async fn read_json<P: DataFilePaths>(
         &self,
         paths: P,
@@ -221,7 +220,6 @@ impl BallistaContext {
     }
 
     /// Create a DataFrame representing an Avro table scan
-    /// TODO fetch schema from scheduler instead of resolving locally
     pub async fn read_avro<P: DataFilePaths>(
         &self,
         paths: P,
@@ -232,7 +230,6 @@ impl BallistaContext {
     }
 
     /// Create a DataFrame representing a Parquet table scan
-    /// TODO fetch schema from scheduler instead of resolving locally
     pub async fn read_parquet<P: DataFilePaths>(
         &self,
         paths: P,
@@ -243,7 +240,6 @@ impl BallistaContext {
     }
 
     /// Create a DataFrame representing a CSV table scan
-    /// TODO fetch schema from scheduler instead of resolving locally
     pub async fn read_csv<P: DataFilePaths>(
         &self,
         paths: P,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

There were some TODO comments for a feature that I had been wanting to implement a long time ago, where a context could interact with a scheduler to get lists of files and resolve schemas, somewhat similar to Spark's new connect feature. I no longer plan on working on this, so we should remove these TODO comments.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Remove some comments

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
