### PR TITLE
Update release verification script to try and publish `cache` crate not `core` crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 # under the License.
 
 apache-rat-*.jar
+rat.txt
+filtered_rat.txt
 arrow-src.tar
 arrow-src.tar.gz
 CHANGELOG.md.bak

--- a/ballista/cache/Cargo.toml
+++ b/ballista/cache/Cargo.toml
@@ -17,7 +17,13 @@
 
 [package]
 name = "ballista-cache"
-version = "0.11.0"
+description = "Ballista Cache"
+license = "Apache-2.0"
+homepage = "https://github.com/apache/arrow-ballista"
+repository = "https://github.com/apache/arrow-ballista"
+readme = "README.md"
+authors = ["Apache Arrow <dev@arrow.apache.org>"]
+version = "0.12.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -46,7 +46,7 @@ s3 = ["object_store/aws"]
 ahash = { version = "0.8", default-features = false }
 arrow-flight = { workspace = true }
 async-trait = "0.1.41"
-ballista-cache = { path = "../cache", version = "0.11.0" }
+ballista-cache = { path = "../cache", version = "0.12.0" }
 bytes = "1.0"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -143,7 +143,7 @@ test_source_distribution() {
 
   # Note can't verify other ballista crates as they depend
   # on ballista-core which isn't published yet
-  pushd ballista/core
+  pushd ballista/cache
     cargo publish --dry-run
   popd
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

0.12.0-rc2 release verification failed because we try and dry-run publish the core crate, but this now depends on the cache crate

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Try and dry-run publish cache crate in release verification script
- Fill out Cargo metadata for cache crate

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
