### PR TITLE
docs: Add ASF attribution

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-sphinx==2.4.4
-pydata-sphinx-theme
-myst-parser<1
-maturin<0.12
+sphinx
+Jinja2
+pydata-sphinx-theme==0.8.0
+myst-parser
+maturin

--- a/docs/source/_templates/docs-sidebar.html
+++ b/docs/source/_templates/docs-sidebar.html
@@ -1,6 +1,6 @@
 
 <a class="navbar-brand" href="{{ pathto(master_doc) }}">
-  <img src="{{ pathto('_static/images/' + logo, 1) }}" class="logo" alt="logo">
+  <img src="{{ pathto('_static/images/ballista-logo.png', 1) }}" class="logo" alt="logo">
 </a>
 
 <form class="bd-search d-flex align-items-center" action="{{ pathto('search') }}" method="get">

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -3,3 +3,24 @@
 {# Silence the navbar #}
 {% block docs_navbar %}
 {% endblock %}
+
+<!--
+    Custom footer
+-->
+{% block footer %}
+<!-- Based on pydata_sphinx_theme/footer.html -->
+<footer class="footer mt-5 mt-md-0">
+  <div class="container">
+    {% for footer_item in theme_footer_items %}
+    <div class="footer-item">
+      {% include footer_item %}
+    </div>
+    {% endfor %}
+    <div class="footer-item">
+      <p>Apache Arrow DataFusion, Arrow DataFusion, Apache, the Apache feather logo, and the Apache Arrow DataFusion project logo</p>
+      <p>are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</p>
+    </div>
+  </div>
+</footer>
+
+{% endblock %}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -17,7 +17,7 @@
     </div>
     {% endfor %}
     <div class="footer-item">
-      <p>Apache Arrow DataFusion, Arrow DataFusion, Apache, the Apache feather logo, and the Apache Arrow DataFusion project logo</p>
+      <p>Apache Arrow Ballista, Arrow Ballista, Apache, the Apache feather logo, and the Apache Arrow Ballista project logo</p>
       <p>are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</p>
     </div>
   </div>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'Apache Arrow DataFusion'
+project = 'Apache Arrow Ballista'
 copyright = '2019-2024, Apache Software Foundation'
 author = 'Apache Software Foundation'
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,8 +31,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-import datafusion
-
 # -- Project information -----------------------------------------------------
 
 project = 'Apache Arrow DataFusion'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,9 +35,9 @@ import datafusion
 
 # -- Project information -----------------------------------------------------
 
-project = 'Arrow DataFusion'
-copyright = '2022, Apache Software Foundation'
-author = 'Arrow DataFusion Authors'
+project = 'Apache Arrow DataFusion'
+copyright = '2019-2024, Apache Software Foundation'
+author = 'Apache Software Foundation'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
# Which issue does this PR close?
Closes #950 

 # Rationale for this change
Aligning Apache Software Foundation attribution across projects

# What changes are included in this PR?
- Add ASF footer
- Update docs requirements.txt (align with arrow-datafusion)
- Fix issues preventing docs compilation

# Are there any user-facing changes?
Updated footer on documentation website

![image](https://github.com/apache/arrow-ballista/assets/10134699/7b9ada7d-75d3-46bf-be32-a3a720fee1be)
