### PR TITLE
build: Fix the ballista-cli Dockerfile

### DIFF
--- a/ballista-cli/Dockerfile
+++ b/ballista-cli/Dockerfile
@@ -15,15 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.59 as builder
-
-COPY ./datafusion /usr/src/datafusion
+FROM rust:1.72 as builder
 
 COPY ./ballista-cli /usr/src/ballista-cli
 
 COPY ./ballista /usr/src/ballista
 
+COPY ./benchmarks /usr/src/benchmarks
+
+COPY ./examples /usr/src/examples
+
+COPY ./Cargo.toml /usr/src/Cargo.toml
+
 WORKDIR /usr/src/ballista-cli
+
+RUN apt-get update && apt-get install -y protobuf-compiler
 
 RUN rustup component add rustfmt
 
@@ -31,7 +37,7 @@ RUN cargo build --release
 
 FROM debian:bullseye-slim
 
-COPY --from=builder /usr/src/ballista-cli/target/release/ballista-cli /usr/local/bin
+COPY --from=builder /usr/src/target/release/ballista-cli /usr/local/bin
 
 ENTRYPOINT ["ballista-cli"]
 

--- a/ballista-cli/Dockerfile
+++ b/ballista-cli/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.72 as builder
+FROM rust:1.76-bullseye as builder
 
 COPY ./ballista-cli /usr/src/ballista-cli
 


### PR DESCRIPTION
# Which issue does this PR close?

```
package `ahash v0.8.8` cannot be built because it requires rustc 1.72.0 or newer
```

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
