### PR TITLE
docs: list protoc dependency

### DIFF
--- a/docs/source/contributors-guide/development.md
+++ b/docs/source/contributors-guide/development.md
@@ -40,6 +40,7 @@ bottom right corner of the IDE.
 If you are not using the Dev Container or VScode, you will need to install these dependencies yourself.
 
 - [Rust](https://www.rust-lang.org/tools/install)
+- [Protobuf Compiler](https://protobuf.dev/downloads/) is required to build the project.
 - [Node.js](https://nodejs.org/en/download/) is required to build the project.
 - [Yarn](https://classic.yarnpkg.com/en/docs/install) is required to build the UI.
 - [Docker](https://docs.docker.com/get-docker/) is required to run the integration tests.

--- a/docs/source/user-guide/deployment/quick-start.md
+++ b/docs/source/user-guide/deployment/quick-start.md
@@ -24,6 +24,7 @@ A simple way to start a local cluster for testing purposes is to use cargo to bu
 Project Requirements:
 
 - [Rust](https://www.rust-lang.org/tools/install)
+- [Protobuf Compiler](https://protobuf.dev/downloads/)
 - [Node.js](https://nodejs.org/en/download)
 - [Yarn](https://classic.yarnpkg.com/lang/en/docs/install)
 


### PR DESCRIPTION

 # Rationale for this change


While following the [quick start] guide, I ran into a compilation error when prost tried to build the proto files. Installing the protobuf compiler allowed me to follow the rest of the quick start guide.

I also noticed the manual setup section of the contributors guide had a similar list of dependencies that was missing the protobuf compiler.

[quick start]: https://arrow.apache.org/ballista/user-guide/deployment/quick-start.html

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Since installing the protobuf compiler was sufficient for me to build the project, I thought it made sense to document this so others following the docs would be aware of the dependency.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No -- only documentation changes.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
